### PR TITLE
Catch exceptions in CancellationToken Register delegate

### DIFF
--- a/CliWrap/Cli.cs
+++ b/CliWrap/Cli.cs
@@ -98,9 +98,16 @@ namespace CliWrap
                 // and also after standard input so that it can write correctly
                 cancellationToken.Register(() =>
                 {
-                    // Kill process
-                    // ReSharper disable once AccessToDisposedClosure
-                    process.Kill();
+                    // Try to kill process
+                    try
+                    {
+                        // ReSharper disable once AccessToDisposedClosure
+                        process.Kill();
+                    }
+                    catch (Exception)
+                    {
+                        // Just ignore if you can't kill
+                    }
                 });
 
                 // Begin reading stdout and stderr
@@ -212,9 +219,16 @@ namespace CliWrap
                 // and also after standard input so that it can write correctly
                 cancellationToken.Register(() =>
                 {
-                    // Kill process
-                    // ReSharper disable once AccessToDisposedClosure
-                    process.Kill();
+                    // Try to kill process
+                    try
+                    {
+                        // ReSharper disable once AccessToDisposedClosure
+                        process.Kill();
+                    }
+                    catch (Exception)
+                    {
+                        // Just ignore if you can't kill
+                    }
                 });
 
                 // Begin reading stdout and stderr

--- a/CliWrap/Cli.cs
+++ b/CliWrap/Cli.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using CliWrap.Internal;
 using CliWrap.Models;
 using System.Text;
 
@@ -99,15 +100,8 @@ namespace CliWrap
                 cancellationToken.Register(() =>
                 {
                     // Try to kill process
-                    try
-                    {
-                        // ReSharper disable once AccessToDisposedClosure
-                        process.Kill();
-                    }
-                    catch (Exception)
-                    {
-                        // Just ignore if you can't kill
-                    }
+                    // ReSharper disable once AccessToDisposedClosure
+                    process.KillIfRunning();
                 });
 
                 // Begin reading stdout and stderr
@@ -220,15 +214,8 @@ namespace CliWrap
                 cancellationToken.Register(() =>
                 {
                     // Try to kill process
-                    try
-                    {
-                        // ReSharper disable once AccessToDisposedClosure
-                        process.Kill();
-                    }
-                    catch (Exception)
-                    {
-                        // Just ignore if you can't kill
-                    }
+                    // ReSharper disable once AccessToDisposedClosure
+                    process.KillIfRunning();
                 });
 
                 // Begin reading stdout and stderr

--- a/CliWrap/Cli.cs
+++ b/CliWrap/Cli.cs
@@ -99,7 +99,7 @@ namespace CliWrap
                 // and also after standard input so that it can write correctly
                 cancellationToken.Register(() =>
                 {
-                    // Try to kill process
+                    // Kill process if it's not dead already
                     // ReSharper disable once AccessToDisposedClosure
                     process.KillIfRunning();
                 });
@@ -213,7 +213,7 @@ namespace CliWrap
                 // and also after standard input so that it can write correctly
                 cancellationToken.Register(() =>
                 {
-                    // Try to kill process
+                    // Kill process if it's not dead already
                     // ReSharper disable once AccessToDisposedClosure
                     process.KillIfRunning();
                 });

--- a/CliWrap/Internal/Extensions.cs
+++ b/CliWrap/Internal/Extensions.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace CliWrap.Internal
+{
+    internal static class Extensions
+    {
+        public static bool KillIfRunning(this Process process)
+        {
+            try
+            {
+                process.Kill();
+                return true;
+            }
+            catch (InvalidOperationException)
+            {
+                return false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
I have an issue that this patch resolves.

I'm running a lot (about a 150) cli applications in background, using ExecuteAsync with CancellationToken for timeouts. And it's actually common that the line process.Kill() is throwing exception (i'm not really sure why is that happening. Process is already killed, but process.Wait doesn't return). And, while this exception wasn't handled, it crashed my whole application.

Maybe it should be handled other way? Maybe some callback to user then exception occurs?