### PR TITLE
.NET Standard, .NET 4.7, new NuGet version number

### DIFF
--- a/CliWrap.Tests/CliWrap.Tests.csproj
+++ b/CliWrap.Tests/CliWrap.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net47</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CliWrap.sln
+++ b/CliWrap.sln
@@ -1,17 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.12
+VisualStudioVersion = 15.0.26730.16
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{43514CCF-887D-43B9-81D0-A9930FE73772}"
-	ProjectSection(SolutionItems) = preProject
-		License.txt = License.txt
-		Readme.md = Readme.md
-	EndProjectSection
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CliWrap", "CliWrap\CliWrap.csproj", "{5CEBC7E7-A585-4802-AFCE-F050BE1F000F}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CliWrap", "CliWrap\CliWrap.csproj", "{03ECCB7F-144F-4742-BF68-7F84026DA775}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CliWrap.Tests", "CliWrap.Tests\CliWrap.Tests.csproj", "{890D9A75-4B00-4D89-AAF8-936726B45410}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CliWrap.Tests", "CliWrap.Tests\CliWrap.Tests.csproj", "{624D9559-DADC-412F-8043-552A94602BA1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -19,19 +13,19 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{03ECCB7F-144F-4742-BF68-7F84026DA775}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{03ECCB7F-144F-4742-BF68-7F84026DA775}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{03ECCB7F-144F-4742-BF68-7F84026DA775}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{03ECCB7F-144F-4742-BF68-7F84026DA775}.Release|Any CPU.Build.0 = Release|Any CPU
-		{890D9A75-4B00-4D89-AAF8-936726B45410}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{890D9A75-4B00-4D89-AAF8-936726B45410}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{890D9A75-4B00-4D89-AAF8-936726B45410}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{890D9A75-4B00-4D89-AAF8-936726B45410}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5CEBC7E7-A585-4802-AFCE-F050BE1F000F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5CEBC7E7-A585-4802-AFCE-F050BE1F000F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5CEBC7E7-A585-4802-AFCE-F050BE1F000F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5CEBC7E7-A585-4802-AFCE-F050BE1F000F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{624D9559-DADC-412F-8043-552A94602BA1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{624D9559-DADC-412F-8043-552A94602BA1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{624D9559-DADC-412F-8043-552A94602BA1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{624D9559-DADC-412F-8043-552A94602BA1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {E62AAC63-51EC-45A1-A500-7B073424CA8C}
+		SolutionGuid = {C422B4BD-5562-4EE2-8ED2-BE5209A523AC}
 	EndGlobalSection
 EndGlobal

--- a/CliWrap/CliWrap.csproj
+++ b/CliWrap/CliWrap.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp1.0</TargetFrameworks>
-    <Version>1.5.1</Version>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Version>1.5.2</Version>
     <Company>Tyrrrz</Company>
     <Authors>$(Company)</Authors>
     <Copyright>Copyright (C) 2017 Alexey Golub</Copyright>


### PR DESCRIPTION
Converted CliWrap to .NET standard 2, upgraded CliWrap.Tests to .NET 4.7, and upped the NuGet version number.

This will be helpful so I can use this NuGet package in a .NET Standard project I'm working on, so feel free to push the NuGet package out sooner rather than later :)