### PR TITLE
Added option to not throw on cancel

### DIFF
--- a/CliWrap/Cli.cs
+++ b/CliWrap/Cli.cs
@@ -15,6 +15,11 @@ namespace CliWrap
     public class Cli
     {
         /// <summary>
+        /// Whether to throw exception when the process has been cancelled
+        /// </summary>
+        public static bool ThrowOnCancel { get; set; } = false;
+
+        /// <summary>
         /// Target file path
         /// </summary>
         public string FilePath { get; }
@@ -112,13 +117,14 @@ namespace CliWrap
                 process.WaitForExit();
 
                 // Check cancellation
-                cancellationToken.ThrowIfCancellationRequested();
+                if (ThrowOnCancel)
+                    cancellationToken.ThrowIfCancellationRequested();
 
                 // Get stdout and stderr
                 var stdOut = stdOutBuffer.ToString();
                 var stdErr = stdErrBuffer.ToString();
 
-                return new ExecutionOutput(process.ExitCode, stdOut, stdErr);
+                return new ExecutionOutput(process.ExitCode, stdOut, stdErr, cancellationToken.IsCancellationRequested);
             }
         }
 

--- a/CliWrap/Models/ExecutionOutput.cs
+++ b/CliWrap/Models/ExecutionOutput.cs
@@ -27,12 +27,18 @@ namespace CliWrap.Models
         /// </summary>
         public bool HasError => !string.IsNullOrEmpty(StandardError);
 
+        /// <summary>
+        /// Whether the process has been abruptly terminated
+        /// </summary>
+        public bool WasCancelled { get; }
+
         /// <inheritdoc />
-        public ExecutionOutput(int exitCode, string standardOutput, string standardError)
+        public ExecutionOutput(int exitCode, string standardOutput, string standardError, bool cancelled = false)
         {
             ExitCode = exitCode;
             StandardOutput = standardOutput;
             StandardError = standardError;
+            WasCancelled = cancelled;
         }
 
         /// <summary>


### PR DESCRIPTION
I added the possibility of not throwing an exception when killing the process using the `CancellationToken`, but instead set a boolean on the return value.