### PR TITLE
Added configuration options for encoding of stdin, stdout and stderr

### DIFF
--- a/CliWrap/Cli.cs
+++ b/CliWrap/Cli.cs
@@ -32,30 +32,32 @@ namespace CliWrap
         /// <summary>
         /// Encoding of stdin, stdout and stderr
         /// </summary>
-        public Encoding Encoding { get; }
+        public EncodingSettings EncodingSettings { get; }
 
         /// <summary>
         /// Initializes wrapper on a target executable using given working directory and encoding.
         /// </summary>
         /// <param name="filePath">File path of the target executable.</param>
         /// <param name="workingDirectory">Target executable's working directory.</param>
-        /// <param name="encoding">Encoding of stdin, stdout and stderr</param>
-        public Cli(string filePath, string workingDirectory, Encoding encoding)
+        /// <param name="encodingSettings">Encodings to use for input/output streams</param>
+        public Cli(string filePath, string workingDirectory, EncodingSettings encodingSettings)
         {
             FilePath = filePath.GuardNotNull(nameof(filePath));
             WorkingDirectory = workingDirectory.GuardNotNull(nameof(workingDirectory));
-            Encoding = encoding.GuardNotNull(nameof(encoding));
+            EncodingSettings = encodingSettings.GuardNotNull(nameof(encodingSettings));
 
             _killSwitchCts = new CancellationTokenSource();
         }
 
         /// <summary>
         /// Initializes wrapper on a target executable using given working directory.
+        /// The encodings default to <see cref="Console.InputEncoding"/> for stdin and
+        /// <see cref="Console.OutputEncoding"/> for stdout and stderr.
         /// </summary>
         /// <param name="filePath">File path of the target executable.</param>
         /// <param name="workingDirectory">Target executable's working directory.</param>
         public Cli(string filePath, string workingDirectory)
-            : this(filePath, workingDirectory, Encoding.ASCII)
+            : this(filePath, workingDirectory, new EncodingSettings())
         {
         }
 
@@ -64,9 +66,9 @@ namespace CliWrap
         /// using current directory as working directory.
         /// </summary>
         /// <param name="filePath">File path of the target executable.</param>
-        /// <param name="encoding">Encoding of stdin, stdout and stderr</param>
-        public Cli(string filePath, Encoding encoding)
-            : this(filePath, Directory.GetCurrentDirectory(), encoding)
+        /// <param name="encodingSettings">Encodings to use for input/output streams</param>
+        public Cli(string filePath, EncodingSettings encodingSettings)
+            : this(filePath, Directory.GetCurrentDirectory(), encodingSettings)
         {
         }
 
@@ -93,8 +95,8 @@ namespace CliWrap
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
                     RedirectStandardInput = true,
-                    StandardOutputEncoding = Encoding,
-                    StandardErrorEncoding = Encoding,
+                    StandardOutputEncoding = EncodingSettings.StandardOutput,
+                    StandardErrorEncoding = EncodingSettings.StandardError,
                     UseShellExecute = false
                 },
                 EnableRaisingEvents = true
@@ -177,7 +179,7 @@ namespace CliWrap
                 // Write stdin
                 using (process.StandardInput) {
                     if (input.StandardInput != null) {
-                        var bytes = Encoding.GetBytes(input.StandardInput);
+                        var bytes = EncodingSettings.StandardInput.GetBytes(input.StandardInput);
                         var stdin = process.StandardInput.BaseStream;
                         stdin.Write(bytes, 0, bytes.Length);
                     }
@@ -255,7 +257,7 @@ namespace CliWrap
                 // Write stdin
                 using (process.StandardInput) {
                     if (input.StandardInput != null) {
-                        var bytes = Encoding.GetBytes(input.StandardInput);
+                        var bytes = EncodingSettings.StandardInput.GetBytes(input.StandardInput);
                         var stdin = process.StandardInput.BaseStream;
                         stdin.Write(bytes, 0, bytes.Length);
                     }
@@ -347,7 +349,7 @@ namespace CliWrap
                 // Write stdin
                 using (process.StandardInput) {
                     if (input.StandardInput != null) {
-                        var bytes = Encoding.GetBytes(input.StandardInput);
+                        var bytes = EncodingSettings.StandardInput.GetBytes(input.StandardInput);
                         var stdin = process.StandardInput.BaseStream;
                         await stdin.WriteAsync(bytes, 0, bytes.Length, linkedToken).ConfigureAwait(false); 
                     }

--- a/CliWrap/Cli.cs
+++ b/CliWrap/Cli.cs
@@ -30,7 +30,7 @@ namespace CliWrap
         public string WorkingDirectory { get; }
 
         /// <summary>
-        /// Encoding of stdin, stdout and stderr
+        /// Encodings to use for standard input, output and error.
         /// </summary>
         public EncodingSettings EncodingSettings { get; }
 
@@ -39,7 +39,7 @@ namespace CliWrap
         /// </summary>
         /// <param name="filePath">File path of the target executable.</param>
         /// <param name="workingDirectory">Target executable's working directory.</param>
-        /// <param name="encodingSettings">Encodings to use for input/output streams</param>
+        /// <param name="encodingSettings">Encodings to use for input/output streams.</param>
         public Cli(string filePath, string workingDirectory, EncodingSettings encodingSettings)
         {
             FilePath = filePath.GuardNotNull(nameof(filePath));
@@ -51,13 +51,11 @@ namespace CliWrap
 
         /// <summary>
         /// Initializes wrapper on a target executable using given working directory.
-        /// The encodings default to <see cref="Console.InputEncoding"/> for stdin and
-        /// <see cref="Console.OutputEncoding"/> for stdout and stderr.
         /// </summary>
         /// <param name="filePath">File path of the target executable.</param>
         /// <param name="workingDirectory">Target executable's working directory.</param>
         public Cli(string filePath, string workingDirectory)
-            : this(filePath, workingDirectory, new EncodingSettings())
+            : this(filePath, workingDirectory, EncodingSettings.Default)
         {
         }
 
@@ -66,7 +64,7 @@ namespace CliWrap
         /// using current directory as working directory.
         /// </summary>
         /// <param name="filePath">File path of the target executable.</param>
-        /// <param name="encodingSettings">Encodings to use for input/output streams</param>
+        /// <param name="encodingSettings">Encodings to use for input/output streams.</param>
         public Cli(string filePath, EncodingSettings encodingSettings)
             : this(filePath, Directory.GetCurrentDirectory(), encodingSettings)
         {
@@ -104,7 +102,7 @@ namespace CliWrap
 
             // Set environment variables
 #if NET45
-            foreach (var variable in input.EnvironmentVariables)                
+            foreach (var variable in input.EnvironmentVariables)
                 process.StartInfo.EnvironmentVariables.Add(variable.Key, variable.Value);
 #else
             foreach (var variable in input.EnvironmentVariables)
@@ -177,11 +175,13 @@ namespace CliWrap
                 process.BeginErrorReadLine();
 
                 // Write stdin
-                using (process.StandardInput) {
-                    if (input.StandardInput != null) {
-                        var bytes = EncodingSettings.StandardInput.GetBytes(input.StandardInput);
-                        var stdin = process.StandardInput.BaseStream;
-                        stdin.Write(bytes, 0, bytes.Length);
+                using (process.StandardInput)
+                {
+                    if (input.StandardInput != null)
+                    {
+                        var stdinData = EncodingSettings.StandardInput.GetBytes(input.StandardInput);
+                        var stdinStream = process.StandardInput.BaseStream;
+                        stdinStream.Write(stdinData, 0, stdinData.Length);
                     }
                 }
 
@@ -255,11 +255,13 @@ namespace CliWrap
                 process.Start();
 
                 // Write stdin
-                using (process.StandardInput) {
-                    if (input.StandardInput != null) {
-                        var bytes = EncodingSettings.StandardInput.GetBytes(input.StandardInput);
-                        var stdin = process.StandardInput.BaseStream;
-                        stdin.Write(bytes, 0, bytes.Length);
+                using (process.StandardInput)
+                {
+                    if (input.StandardInput != null)
+                    {
+                        var stdinData = EncodingSettings.StandardInput.GetBytes(input.StandardInput);
+                        var stdinStream = process.StandardInput.BaseStream;
+                        stdinStream.Write(stdinData, 0, stdinData.Length);
                     }
                 }
             }
@@ -347,11 +349,13 @@ namespace CliWrap
                 process.BeginErrorReadLine();
 
                 // Write stdin
-                using (process.StandardInput) {
-                    if (input.StandardInput != null) {
-                        var bytes = EncodingSettings.StandardInput.GetBytes(input.StandardInput);
-                        var stdin = process.StandardInput.BaseStream;
-                        await stdin.WriteAsync(bytes, 0, bytes.Length, linkedToken).ConfigureAwait(false); 
+                using (process.StandardInput)
+                {
+                    if (input.StandardInput != null)
+                    {
+                        var stdinData = EncodingSettings.StandardInput.GetBytes(input.StandardInput);
+                        var stdinStream = process.StandardInput.BaseStream;
+                        await stdinStream.WriteAsync(stdinData, 0, stdinData.Length, linkedToken).ConfigureAwait(false);
                     }
                 }
 

--- a/CliWrap/Cli.cs
+++ b/CliWrap/Cli.cs
@@ -176,9 +176,11 @@ namespace CliWrap
 
                 // Write stdin
                 using (process.StandardInput) {
-                    var bytes = Encoding.GetBytes(input.StandardInput);
-                    var stdin = process.StandardInput.BaseStream;
-                    stdin.Write(bytes, 0, bytes.Length);
+                    if (input.StandardInput != null) {
+                        var bytes = Encoding.GetBytes(input.StandardInput);
+                        var stdin = process.StandardInput.BaseStream;
+                        stdin.Write(bytes, 0, bytes.Length);
+                    }
                 }
 
                 // Setup cancellation token
@@ -252,9 +254,11 @@ namespace CliWrap
 
                 // Write stdin
                 using (process.StandardInput) {
-                    var bytes = Encoding.GetBytes(input.StandardInput);
-                    var stdin = process.StandardInput.BaseStream;
-                    stdin.Write(bytes, 0, bytes.Length);
+                    if (input.StandardInput != null) {
+                        var bytes = Encoding.GetBytes(input.StandardInput);
+                        var stdin = process.StandardInput.BaseStream;
+                        stdin.Write(bytes, 0, bytes.Length);
+                    }
                 }
             }
         }
@@ -342,9 +346,11 @@ namespace CliWrap
 
                 // Write stdin
                 using (process.StandardInput) {
-                    var bytes = Encoding.GetBytes(input.StandardInput);
-                    var stdin = process.StandardInput.BaseStream;
-                    await stdin.WriteAsync(bytes, 0, bytes.Length, linkedToken).ConfigureAwait(false); 
+                    if (input.StandardInput != null) {
+                        var bytes = Encoding.GetBytes(input.StandardInput);
+                        var stdin = process.StandardInput.BaseStream;
+                        await stdin.WriteAsync(bytes, 0, bytes.Length, linkedToken).ConfigureAwait(false); 
+                    }
                 }
 
                 // Setup cancellation token

--- a/CliWrap/Models/EncodingSettings.cs
+++ b/CliWrap/Models/EncodingSettings.cs
@@ -38,11 +38,11 @@ namespace CliWrap.Models
         /// <summary>
         /// Initializes <see cref="EncodingSettings" /> with the same encoding for all streams.
         /// </summary>
-        public EncodingSettings(Encoding all)
+        public EncodingSettings(Encoding inputOutput)
         {
-            StandardInput = all.GuardNotNull(nameof(all));
-            StandardOutput = all;
-            StandardError = all;
+            StandardInput = inputOutput.GuardNotNull(nameof(inputOutput));
+            StandardOutput = inputOutput;
+            StandardError = inputOutput;
         }
 
         /// <summary>

--- a/CliWrap/Models/EncodingSettings.cs
+++ b/CliWrap/Models/EncodingSettings.cs
@@ -7,28 +7,26 @@ namespace CliWrap.Models
     /// <summary>
     /// Specifies the encodings to use for each input/output stream.
     /// </summary>
-    public class EncodingSettings
+    public partial class EncodingSettings
     {
         /// <summary>
-        /// Encoding to use for stdin.
+        /// Encoding to use for standard input.
         /// </summary>
         public Encoding StandardInput { get; }
 
         /// <summary>
-        /// Encoding to use for stdout.
+        /// Encoding to use for standard output.
         /// </summary>
         public Encoding StandardOutput { get; }
 
         /// <summary>
-        /// Encoding to use for stderr.
+        /// Encoding to use for standard error.
         /// </summary>
         public Encoding StandardError { get; }
 
         /// <summary>
-        /// Used default encodings:
-        /// <see cref="Console.InputEncoding"/> for <see cref="StandardInput"/> and
-        /// <see cref="Console.OutputEncoding"/> for both <see cref="StandardOutput"/>
-        /// and <see cref="StandardError"/>.
+        /// Initializes <see cref="EncodingSettings" /> with default encodings
+        /// (<see cref="Console.InputEncoding" /> and <see cref="Console.OutputEncoding" />)
         /// </summary>
         public EncodingSettings()
         {
@@ -38,39 +36,41 @@ namespace CliWrap.Models
         }
 
         /// <summary>
-        /// Use one encoding for all input/output streams.
+        /// Initializes <see cref="EncodingSettings" /> with the same encoding for all streams.
         /// </summary>
-        /// <param name="encoding">Encoding to use.</param>
-        public EncodingSettings(Encoding encoding)
+        public EncodingSettings(Encoding all)
         {
-            StandardInput = encoding.GuardNotNull(nameof(encoding));
-            StandardOutput = encoding;
-            StandardError = encoding;
+            StandardInput = all.GuardNotNull(nameof(all));
+            StandardOutput = all;
+            StandardError = all;
         }
 
         /// <summary>
-        /// Use separate encodings for input and output streams.
+        /// Initializes <see cref="EncodingSettings" /> with separate encoding for input/output streams.
         /// </summary>
-        /// <param name="inputs">Encoding to use for <see cref="StandardInput"/>.</param>
-        /// <param name="outputs">Encoding to use for both <see cref="StandardOutput"/> and <see cref="StandardError"/>.</param>
-        public EncodingSettings(Encoding inputs, Encoding outputs)
+        public EncodingSettings(Encoding input, Encoding output)
         {
-            StandardInput = inputs.GuardNotNull(nameof(inputs));
-            StandardOutput = outputs.GuardNotNull(nameof(outputs));
-            StandardError = outputs;
+            StandardInput = input.GuardNotNull(nameof(input));
+            StandardOutput = output.GuardNotNull(nameof(output));
+            StandardError = output;
         }
 
         /// <summary>
-        /// Use separate encodings for each input/output stream.
+        /// Initializes <see cref="EncodingSettings" /> with separate encodings for all streams.
         /// </summary>
-        /// <param name="standardInput">Encoding to use for <see cref="StandardInput"/>.</param>
-        /// <param name="standardOutput">Encoding to use for <see cref="StandardOutput"/>.</param>
-        /// <param name="standardError">Encoding to use for <see cref="StandardError"/>.</param>
         public EncodingSettings(Encoding standardInput, Encoding standardOutput, Encoding standardError)
         {
             StandardInput = standardInput.GuardNotNull(nameof(standardInput));
             StandardOutput = standardOutput.GuardNotNull(nameof(standardOutput));
             StandardError = standardError.GuardNotNull(nameof(standardError));
         }
+    }
+
+    public partial class EncodingSettings
+    {
+        /// <summary>
+        /// Default encoding settings.
+        /// </summary>
+        public static EncodingSettings Default { get; } = new EncodingSettings();
     }
 }

--- a/CliWrap/Models/EncodingSettings.cs
+++ b/CliWrap/Models/EncodingSettings.cs
@@ -1,0 +1,76 @@
+﻿using CliWrap.Internal;
+using System;
+using System.Text;
+
+namespace CliWrap.Models
+{
+    /// <summary>
+    /// Specifies the encodings to use for each input/output stream.
+    /// </summary>
+    public class EncodingSettings
+    {
+        /// <summary>
+        /// Encoding to use for stdin.
+        /// </summary>
+        public Encoding StandardInput { get; }
+
+        /// <summary>
+        /// Encoding to use for stdout.
+        /// </summary>
+        public Encoding StandardOutput { get; }
+
+        /// <summary>
+        /// Encoding to use for stderr.
+        /// </summary>
+        public Encoding StandardError { get; }
+
+        /// <summary>
+        /// Used default encodings:
+        /// <see cref="Console.InputEncoding"/> for <see cref="StandardInput"/> and
+        /// <see cref="Console.OutputEncoding"/> for both <see cref="StandardOutput"/>
+        /// and <see cref="StandardError"/>.
+        /// </summary>
+        public EncodingSettings()
+        {
+            StandardInput = Console.InputEncoding;
+            StandardOutput = Console.OutputEncoding;
+            StandardError = Console.OutputEncoding;
+        }
+
+        /// <summary>
+        /// Use one encoding for all input/output streams.
+        /// </summary>
+        /// <param name="encoding">Encoding to use.</param>
+        public EncodingSettings(Encoding encoding)
+        {
+            StandardInput = encoding.GuardNotNull(nameof(encoding));
+            StandardOutput = encoding;
+            StandardError = encoding;
+        }
+
+        /// <summary>
+        /// Use separate encodings for input and output streams.
+        /// </summary>
+        /// <param name="inputs">Encoding to use for <see cref="StandardInput"/>.</param>
+        /// <param name="outputs">Encoding to use for both <see cref="StandardOutput"/> and <see cref="StandardError"/>.</param>
+        public EncodingSettings(Encoding inputs, Encoding outputs)
+        {
+            StandardInput = inputs.GuardNotNull(nameof(inputs));
+            StandardOutput = outputs.GuardNotNull(nameof(outputs));
+            StandardError = outputs;
+        }
+
+        /// <summary>
+        /// Use separate encodings for each input/output stream.
+        /// </summary>
+        /// <param name="standardInput">Encoding to use for <see cref="StandardInput"/>.</param>
+        /// <param name="standardOutput">Encoding to use for <see cref="StandardOutput"/>.</param>
+        /// <param name="standardError">Encoding to use for <see cref="StandardError"/>.</param>
+        public EncodingSettings(Encoding standardInput, Encoding standardOutput, Encoding standardError)
+        {
+            StandardInput = standardInput.GuardNotNull(nameof(standardInput));
+            StandardOutput = standardOutput.GuardNotNull(nameof(standardOutput));
+            StandardError = standardError.GuardNotNull(nameof(standardError));
+        }
+    }
+}


### PR DESCRIPTION
User can pass a `System.Text.Encoding` into a constructor. This encoding is used in all three input/output streams of the process.

This is useful, obviously, if one wants to transfer special characters over the IO streams.

The default of `Console.InputEncoding` is `System.Text.SBCSCodePageEncoding`. Since I've never heard about it and this library targets netstandard and netcore I defaulted the encoding to `Encoding.ASCII`.

Btw I could't run any unit tests because my VS said no. I just hope to get it correct.