### PR TITLE
Add callback for stdout/stderr close

### DIFF
--- a/CliWrap.Tests/CliTests.cs
+++ b/CliWrap.Tests/CliTests.cs
@@ -55,6 +55,24 @@ namespace CliWrap.Tests
         }
 
         [Test]
+        public void Execute_StdoutClosedCallback_Test()
+        {
+            var stdoutClosed = false;
+            var stdErrClosed = false;
+
+            // Arrange & act
+            Cli.Wrap(EchoArgsToStdoutBat)
+                .SetArguments(TestString)
+                .SetStandardOutputClosedCallback(() => stdoutClosed = true)
+                .SetStandardErrorClosedCallback(() => stdErrClosed = true)
+                .Execute();
+
+            // Assert
+            Assert.IsTrue(stdoutClosed);
+            Assert.IsTrue(stdErrClosed);
+        }
+
+        [Test]
         public void Execute_EchoFirstArgEscapedToStdout_Test()
         {
             // Arrange & act
@@ -239,6 +257,24 @@ namespace CliWrap.Tests
 
             // Assert
             AssertExecutionResult(result, 0, TestString, "");
+        }
+
+        [Test]
+        public async Task ExecuteAsync_StdoutClosedCallback_Test()
+        {
+            var stdoutClosed = false;
+            var stdErrClosed = false;
+
+            // Arrange & act
+            await Cli.Wrap(EchoArgsToStdoutBat)
+                .SetArguments(TestString)
+                .SetStandardOutputClosedCallback(() => stdoutClosed = true)
+                .SetStandardErrorClosedCallback(() => stdErrClosed = true)
+                .ExecuteAsync();
+
+            // Assert
+            Assert.IsTrue(stdoutClosed);
+            Assert.IsTrue(stdErrClosed);
         }
 
         [Test]

--- a/CliWrap/Cli.cs
+++ b/CliWrap/Cli.cs
@@ -26,7 +26,9 @@ namespace CliWrap
         private Encoding _standardOutputEncoding = Console.OutputEncoding;
         private Encoding _standardErrorEncoding = Console.OutputEncoding;
         private Action<string> _standardOutputObserver;
+        private Action _standardOutputClosedObserver;
         private Action<string> _standardErrorObserver;
+        private Action _standardErrorClosedObserver;
         private CancellationToken _cancellationToken;
         private bool _exitCodeValidation = true;
         private bool _standardErrorValidation;
@@ -188,9 +190,23 @@ namespace CliWrap
         }
 
         /// <inheritdoc />
+        public ICli SetStandardOutputClosedCallback(Action callback)
+        {
+            _standardOutputClosedObserver = callback.GuardNotNull(nameof(callback));
+            return this;
+        }
+
+        /// <inheritdoc />
         public ICli SetStandardErrorCallback(Action<string> callback)
         {
             _standardErrorObserver = callback.GuardNotNull(nameof(callback));
+            return this;
+        }
+
+        /// <inheritdoc />
+        public ICli SetStandardErrorClosedCallback(Action callback)
+        {
+            _standardErrorClosedObserver = callback.GuardNotNull(nameof(callback));
             return this;
         }
 
@@ -241,7 +257,13 @@ namespace CliWrap
 #endif
 
             // Create and start process
-            var process = new CliProcess(startInfo, _standardOutputObserver, _standardErrorObserver);
+            var process = new CliProcess(
+                startInfo, 
+                _standardOutputObserver, 
+                _standardErrorObserver, 
+                _standardOutputClosedObserver,
+                _standardErrorClosedObserver
+            );
             process.Start();
 
             return process;

--- a/CliWrap/ICli.cs
+++ b/CliWrap/ICli.cs
@@ -71,9 +71,19 @@ namespace CliWrap
         ICli SetStandardOutputCallback(Action<string> callback);
 
         /// <summary>
+        /// Sets the delegate that will be called whenever the standard output stream is closed.
+        /// </summary>
+        ICli SetStandardOutputClosedCallback(Action callback);
+
+        /// <summary>
         /// Sets the delegate that will be called whenever a new line is appended to standard error stream.
         /// </summary>
         ICli SetStandardErrorCallback(Action<string> callback);
+
+        /// <summary>
+        /// Sets the delegate that will be called whenever the standard error stream is closed.
+        /// </summary>
+        ICli SetStandardErrorClosedCallback(Action callback);
 
         /// <summary>
         /// Sets the cancellation token.

--- a/CliWrap/Internal/CliProcess.cs
+++ b/CliWrap/Internal/CliProcess.cs
@@ -30,7 +30,8 @@ namespace CliWrap.Internal
         public string StandardError { get; private set; }
 
         public CliProcess(ProcessStartInfo startInfo,
-            Action<string> standardOutputObserver = null, Action<string> standardErrorObserver = null)
+            Action<string> standardOutputObserver = null, Action<string> standardErrorObserver = null,
+            Action standardOutputClosedObserver = null, Action standardErrorClosedObserver = null)
         {
             // Create underlying process
             _nativeProcess = new Process {StartInfo = startInfo};
@@ -70,6 +71,7 @@ namespace CliWrap.Internal
                     StandardOutput = _standardOutputBuffer.ToString();
 
                     // Release signal
+                    standardOutputClosedObserver?.Invoke();
                     _standardOutputEndSignal.Release();
                 }
             };
@@ -91,6 +93,7 @@ namespace CliWrap.Internal
                     StandardError = _standardErrorBuffer.ToString();
 
                     // Release signal
+                    standardErrorClosedObserver?.Invoke();
                     _standardErrorEndSignal.Release();
                 }
             };


### PR DESCRIPTION
Adds two new methods to the public API:
 - `SetStandardOutputClosedCallback`: Called when stdout is closed
 - `SetStandardErrorClosedCallback`: Called when stderr is closed

These can be used to convert the output stream into an Rx `IObservable`, for example (the IObservable needs to know when the stream has completed):
```csharp
var stdOutObservable = Observable.Create<string>(observer =>
{
	wrap.SetStandardOutputCallback(observer.OnNext);
	wrap.SetStandardOutputClosedCallback(observer.OnCompleted);
	return Disposable.Empty;
});
```

For this use case, a slightly awkward thing with the current API is that you need to subscribe to the observable **before** calling `ExecuteAsync`. Any calls to `SetStandardOutputCallback` after `ExecuteAsync` just silently do nothing. This should probably at least throw an exception, although it would also be good to have the ability to attach listeners after starting the process.