### PR TITLE
Support for a Argument Builder

### DIFF
--- a/CliWrap.Tests/CliTests.cs
+++ b/CliWrap.Tests/CliTests.cs
@@ -3,6 +3,8 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using CliWrap.Argument;
+using CliWrap.Argument.ArgumentTypes;
 using CliWrap.Exceptions;
 using CliWrap.Models;
 using CliWrap.Tests.Internal;
@@ -55,6 +57,26 @@ namespace CliWrap.Tests
 
             // Assert
             AssertExecutionResult(result, 0, TestString, "");
+        }
+
+        [Test]
+        public void Execute_EchoArgumentBuilderToStdout_Test() {
+            // Setup the arguments
+            var argbuilder = new ArgumentBuilder();
+            argbuilder.Append("TextArgument1");
+            argbuilder.AppendQuoted("QuotedArgument2");
+            argbuilder.AppendSwitch("testswitch3", "=", "value");
+            argbuilder.AppendSecret("testsecretpassword4");
+
+            var expectedreturn = argbuilder.Render();
+
+            // Arrange & act
+            var result = Cli.Wrap(EchoArgsToStdoutBat)
+                .SetArguments(argbuilder)
+                .Execute();
+
+            // Assert
+            AssertExecutionResult(result, 0, expectedreturn, "");
         }
 
         [Test]

--- a/CliWrap/Argument/ArgumentBuilder.cs
+++ b/CliWrap/Argument/ArgumentBuilder.cs
@@ -1,0 +1,118 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using CliWrap.Argument.ArgumentTypes;
+
+namespace CliWrap.Argument {
+
+    /// <summary> Utility for building process arguments. </summary>
+    public sealed class ArgumentBuilder : IReadOnlyCollection<IProcessArgument> {
+
+        private readonly List<IProcessArgument> _tokens;
+
+        /// <summary>
+        ///     Gets the number of arguments contained in the <see cref="ArgumentBuilder"/>.
+        /// </summary>
+        /// <value> The count. </value>
+        public int Count => _tokens.Count;
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="ArgumentBuilder"/> class.
+        /// </summary>
+        public ArgumentBuilder() {
+            _tokens = new List<IProcessArgument>();
+        }
+
+        /// <summary> Clears all arguments from the builder. </summary>
+        public void Clear() {
+            _tokens.Clear();
+        }
+
+        /// <summary> Appends an argument. </summary>
+        /// <param name="argument"> The argument. </param>
+        public void Append(IProcessArgument argument) {
+            _tokens.Add(argument);
+        }
+
+        /// <summary> Prepends an argument. </summary>
+        /// <param name="argument"> The argument. </param>
+        public void Prepend(IProcessArgument argument) {
+            _tokens.Insert(0, argument);
+        }
+
+        /// <summary>
+        ///     Renders the arguments as a <see cref="string"/>. Sensitive information will be included.
+        /// </summary>
+        /// <returns> A string representation of the arguments. </returns>
+        public string Render() {
+            return string.Join(" ", _tokens.Select(t => t.Render()));
+        }
+
+        /// <summary>
+        ///     Renders the arguments as a <see cref="string"/>. Sensitive information will be redacted.
+        /// </summary>
+        /// <returns> A safe string representation of the arguments. </returns>
+        public string RenderSafe() {
+            return string.Join(" ", _tokens.Select(t => t.RenderSafe()));
+        }
+
+        /// <summary> Tries to filer any unsafe arguments from string. </summary>
+        /// <param name="source"> unsafe source string. </param>
+        /// <returns> Filtered string. </returns>
+        public string FilterUnsafe(string source) {
+            if (string.IsNullOrWhiteSpace(source)) {
+                return source;
+            }
+
+            return _tokens
+                .Select(token => new {
+                    Safe = token.RenderSafe().Trim('"').Trim(),
+                    Unsafe = token.Render().Trim('"').Trim()
+                })
+                .Where(token => token.Safe != token.Unsafe)
+                .Aggregate(
+                    new StringBuilder(source),
+                    (sb, token) => sb.Replace(token.Unsafe, token.Safe),
+                    sb => sb.ToString());
+        }
+
+        /// <summary>
+        ///     Performs an implicit conversion from <see cref="string"/> to
+        ///     <see cref="ArgumentBuilder"/>.
+        /// </summary>
+        /// <param name="value"> The text value to convert. </param>
+        /// <returns> A builder representation of the string. </returns>
+        public static implicit operator ArgumentBuilder(string value) {
+            return FromString(value);
+        }
+
+        /// <summary>
+        ///     Performs a conversion from <see cref="string"/> to
+        ///     <see cref="ArgumentBuilder"/>.
+        /// </summary>
+        /// <param name="value"> The text value to convert. </param>
+        /// <returns> A builder representation of the string. </returns>
+        public static ArgumentBuilder FromString(string value) {
+            var builder = new ArgumentBuilder();
+            builder.Append(new TextArgument(value));
+            return builder;
+        }
+
+        /// <summary> Returns an enumerator that iterates through the collection. </summary>
+        /// <typeparam> Type of the process argument. </typeparam>
+        /// <returns> An enumerator that can be used to iterate through the collection. </returns>
+        IEnumerator<IProcessArgument> IEnumerable<IProcessArgument>.GetEnumerator() {
+            return _tokens.GetEnumerator();
+        }
+
+        /// <summary> Returns an enumerator that iterates through a collection. </summary>
+        /// <returns>
+        ///     An <see cref="T:System.Collections.IEnumerator" /> that can be used to iterate through
+        ///     the collection.
+        /// </returns>
+        IEnumerator IEnumerable.GetEnumerator() {
+            return ((IEnumerable)_tokens).GetEnumerator();
+        }
+    }
+}

--- a/CliWrap/Argument/ArgumentListExtensions.cs
+++ b/CliWrap/Argument/ArgumentListExtensions.cs
@@ -1,0 +1,737 @@
+﻿using System;
+using System.Globalization;
+using CliWrap.Argument.ArgumentTypes;
+
+// ReSharper disable once CheckNamespace
+namespace CliWrap.Argument {
+
+    /// <summary> Contains extension methods for <see cref="ArgumentBuilder" />. </summary>
+    public static class ArgumentListExtensions {
+
+        /// <summary> Appends the specified text to the argument builder. </summary>
+        /// <param name="builder"> The builder. </param>
+        /// <param name="text">    The text to be appended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder Append(this ArgumentBuilder builder, string text) {
+            builder?.Append(new TextArgument(text));
+            return builder;
+        }
+
+        /// <summary> Prepend the specified text to the argument builder. </summary>
+        /// <param name="builder"> The builder. </param>
+        /// <param name="text">    The text to be prepended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder Prepend(this ArgumentBuilder builder, string text) {
+            builder?.Prepend(new TextArgument(text));
+            return builder;
+        }
+
+        /// <summary> Formats and appends the specified text to the argument builder. </summary>
+        /// <exception cref="ArgumentNullException"> <paramref name="format" /> or
+        ///                                          <paramref name="args" /> is null. </exception>
+        /// <exception cref="FormatException">       <paramref name="format" /> is invalid.-or- The index
+        ///                                          of a format item is less than zero, or greater than
+        ///                                          or equal to the length of the
+        ///                                          <paramref name="args" /> array. </exception>
+        /// <param name="builder"> The builder. </param>
+        /// <param name="format">  A composite format string. </param>
+        /// <param name="args">    An object array that contains zero or more objects to format. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder Append(this ArgumentBuilder builder, string format, params object[] args) {
+            var text = string.Format(CultureInfo.InvariantCulture, format, args);
+            return Append(builder, text);
+        }
+
+        /// <summary> Formats and prepends the specified text to the argument builder. </summary>
+        /// <exception cref="ArgumentNullException"> <paramref name="format" /> or
+        ///                                          <paramref name="args" /> is null. </exception>
+        /// <exception cref="FormatException">       <paramref name="format" /> is invalid.-or- The index
+        ///                                          of a format item is less than zero, or greater than
+        ///                                          or equal to the length of the
+        ///                                          <paramref name="args" /> array. </exception>
+        /// <param name="builder"> The builder. </param>
+        /// <param name="format">  A composite format string. </param>
+        /// <param name="args">    An object array that contains zero or more objects to format. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder Prepend(this ArgumentBuilder builder, string format, params object[] args) {
+            var text = string.Format(CultureInfo.InvariantCulture, format, args);
+            return Prepend(builder, text);
+        }
+
+        /// <summary> Quotes and appends the specified text to the argument builder. </summary>
+        /// <param name="builder"> The builder. </param>
+        /// <param name="text">    The text to be quoted and appended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder AppendQuoted(this ArgumentBuilder builder, string text) {
+            builder?.Append(new QuotedArgument(new TextArgument(text)));
+            return builder;
+        }
+
+        /// <summary> Quotes and prepends the specified text to the argument builder. </summary>
+        /// <param name="builder"> The builder. </param>
+        /// <param name="text">    The text to be quoted and prepended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder PrependQuoted(this ArgumentBuilder builder, string text) {
+            builder?.Prepend(new QuotedArgument(new TextArgument(text)));
+            return builder;
+        }
+
+        /// <summary> Formats, quotes and appends the specified text to the argument builder. </summary>
+        /// <exception cref="ArgumentNullException"> <paramref name="format" /> or
+        ///                                          <paramref name="args" /> is null. </exception>
+        /// <exception cref="FormatException">       <paramref name="format" /> is invalid.-or- The index
+        ///                                          of a format item is less than zero, or greater than
+        ///                                          or equal to the length of the
+        ///                                          <paramref name="args" /> array. </exception>
+        /// <param name="builder"> The builder. </param>
+        /// <param name="format">  A composite format string to be quoted and appended. </param>
+        /// <param name="args">    An object array that contains zero or more objects to format. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder AppendQuoted(this ArgumentBuilder builder, string format, params object[] args) {
+            var text = string.Format(CultureInfo.InvariantCulture, format, args);
+            return AppendQuoted(builder, text);
+        }
+
+        /// <summary> Formats, quotes and prepends the specified text to the argument builder. </summary>
+        /// <exception cref="ArgumentNullException"> <paramref name="format" /> or
+        ///                                          <paramref name="args" /> is null. </exception>
+        /// <exception cref="FormatException">       <paramref name="format" /> is invalid.-or- The index
+        ///                                          of a format item is less than zero, or greater than
+        ///                                          or equal to the length of the
+        ///                                          <paramref name="args" /> array. </exception>
+        /// <param name="builder"> The builder. </param>
+        /// <param name="format">  A composite format string to be quoted and prepended. </param>
+        /// <param name="args">    An object array that contains zero or more objects to format. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder PrependQuoted(this ArgumentBuilder builder, string format, params object[] args) {
+            var text = string.Format(CultureInfo.InvariantCulture, format, args);
+            return PrependQuoted(builder, text);
+        }
+
+        /// <summary> Quotes and appends the specified argument to the argument builder. </summary>
+        /// <param name="builder">  The builder. </param>
+        /// <param name="argument"> The argument to be quoted and appended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder AppendQuoted(this ArgumentBuilder builder, IProcessArgument argument) {
+            builder?.Append(new QuotedArgument(argument));
+            return builder;
+        }
+
+        /// <summary> Quotes and prepends the specified argument to the argument builder. </summary>
+        /// <param name="builder">  The builder. </param>
+        /// <param name="argument"> The argument to be quoted and prepended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder PrependQuoted(this ArgumentBuilder builder, IProcessArgument argument) {
+            builder?.Prepend(new QuotedArgument(argument));
+            return builder;
+        }
+
+        /// <summary> Appends the specified secret text to the argument builder. </summary>
+        /// <param name="builder"> The builder. </param>
+        /// <param name="text">    The secret text to be appended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder AppendSecret(this ArgumentBuilder builder, string text) {
+            builder?.Append(new SecretArgument(new TextArgument(text)));
+            return builder;
+        }
+
+        /// <summary> Prepends the specified secret text to the argument builder. </summary>
+        /// <param name="builder"> The builder. </param>
+        /// <param name="text">    The secret text to be prepended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder PrependSecret(this ArgumentBuilder builder, string text) {
+            builder?.Prepend(new SecretArgument(new TextArgument(text)));
+            return builder;
+        }
+
+        /// <summary> Formats and appends the specified secret text to the argument builder. </summary>
+        /// <exception cref="ArgumentNullException"> <paramref name="format" /> or
+        ///                                          <paramref name="args" /> is null. </exception>
+        /// <exception cref="FormatException">       <paramref name="format" /> is invalid.-or- The index
+        ///                                          of a format item is less than zero, or greater than
+        ///                                          or equal to the length of the
+        ///                                          <paramref name="args" /> array. </exception>
+        /// <param name="builder"> The builder. </param>
+        /// <param name="format">  A composite format string for the secret text to be appended. </param>
+        /// <param name="args">    An object array that contains zero or more objects to format. </param>
+        /// <returns> The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///           chained. </returns>
+        /// <returns> The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///           chained. </returns>
+        public static ArgumentBuilder AppendSecret(this ArgumentBuilder builder, string format, params object[] args) {
+            var text = string.Format(CultureInfo.InvariantCulture, format, args);
+            return AppendSecret(builder, text);
+        }
+
+        /// <summary> Formats and prepend the specified secret text to the argument builder. </summary>
+        /// <exception cref="ArgumentNullException"> <paramref name="format" /> or
+        ///                                          <paramref name="args" /> is null. </exception>
+        /// <exception cref="FormatException">       <paramref name="format" /> is invalid.-or- The index
+        ///                                          of a format item is less than zero, or greater than
+        ///                                          or equal to the length of the
+        ///                                          <paramref name="args" /> array. </exception>
+        /// <param name="builder"> The builder. </param>
+        /// <param name="format">  A composite format string for the secret text to be prepended. </param>
+        /// <param name="args">    An object array that contains zero or more objects to format. </param>
+        /// <returns> The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///           chained. </returns>
+        /// <returns> The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///           chained. </returns>
+        public static ArgumentBuilder PrependSecret(this ArgumentBuilder builder, string format, params object[] args) {
+            var text = string.Format(CultureInfo.InvariantCulture, format, args);
+            return PrependSecret(builder, text);
+        }
+
+        /// <summary> Appends the specified secret text to the argument builder. </summary>
+        /// <param name="builder">  The builder. </param>
+        /// <param name="argument"> The secret argument to be appended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder AppendSecret(this ArgumentBuilder builder, IProcessArgument argument) {
+            builder?.Append(new SecretArgument(argument));
+            return builder;
+        }
+
+        /// <summary> Prepend the specified secret text to the argument builder. </summary>
+        /// <param name="builder">  The builder. </param>
+        /// <param name="argument"> The secret argument to be prepended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder PrependSecret(this ArgumentBuilder builder, IProcessArgument argument) {
+            builder?.Prepend(new SecretArgument(argument));
+            return builder;
+        }
+
+        /// <summary> Quotes and appends the specified secret text to the argument builder. </summary>
+        /// <param name="builder"> The builder. </param>
+        /// <param name="text">    The secret text to be quoted and appended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder AppendQuotedSecret(this ArgumentBuilder builder, string text) {
+            builder?.AppendQuoted(new SecretArgument(new TextArgument(text)));
+            return builder;
+        }
+
+        /// <summary> Quotes and prepends the specified secret text to the argument builder. </summary>
+        /// <param name="builder"> The builder. </param>
+        /// <param name="text">    The secret text to be quoted and prepended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder PrependQuotedSecret(this ArgumentBuilder builder, string text) {
+            builder?.PrependQuoted(new SecretArgument(new TextArgument(text)));
+            return builder;
+        }
+
+        /// <summary>
+        ///     Formats, quotes and appends the specified secret text to the argument builder.
+        /// </summary>
+        /// <exception cref="ArgumentNullException"> <paramref name="format" /> or
+        ///                                          <paramref name="args" /> is null. </exception>
+        /// <exception cref="FormatException">       <paramref name="format" /> is invalid.-or- The index
+        ///                                          of a format item is less than zero, or greater than
+        ///                                          or equal to the length of the
+        ///                                          <paramref name="args" /> array. </exception>
+        /// <param name="builder"> The builder. </param>
+        /// <param name="format">  A composite format string for the secret text to be quoted and
+        ///                        appended. </param>
+        /// <param name="args">    An object array that contains zero or more objects to format. </param>
+        /// <returns> The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///           chained. </returns>
+        /// <returns> The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///           chained. </returns>
+        public static ArgumentBuilder AppendQuotedSecret(this ArgumentBuilder builder, string format, params object[] args) {
+            var text = string.Format(CultureInfo.InvariantCulture, format, args);
+            return AppendQuotedSecret(builder, text);
+        }
+
+        /// <summary>
+        ///     Formats, quotes and prepends the specified secret text to the argument builder.
+        /// </summary>
+        /// <exception cref="ArgumentNullException"> <paramref name="format" /> or
+        ///                                          <paramref name="args" /> is null. </exception>
+        /// <exception cref="FormatException">       <paramref name="format" /> is invalid.-or- The index
+        ///                                          of a format item is less than zero, or greater than
+        ///                                          or equal to the length of the
+        ///                                          <paramref name="args" /> array. </exception>
+        /// <param name="builder"> The builder. </param>
+        /// <param name="format">  A composite format string for the secret text to be quoted and
+        ///                        prepended. </param>
+        /// <param name="args">    An object array that contains zero or more objects to format. </param>
+        /// <returns> The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///           chained. </returns>
+        /// <returns> The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///           chained. </returns>
+        public static ArgumentBuilder PrependQuotedSecret(this ArgumentBuilder builder, string format, params object[] args) {
+            var text = string.Format(CultureInfo.InvariantCulture, format, args);
+            return PrependQuotedSecret(builder, text);
+        }
+
+        /// <summary> Quotes and appends the specified secret text to the argument builder. </summary>
+        /// <param name="builder">  The builder. </param>
+        /// <param name="argument"> The secret argument to be appended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder AppendQuotedSecret(this ArgumentBuilder builder, IProcessArgument argument) {
+            builder?.AppendQuoted(new SecretArgument(argument));
+            return builder;
+        }
+
+        /// <summary> Quotes and prepends the specified secret text to the argument builder. </summary>
+        /// <param name="builder">  The builder. </param>
+        /// <param name="argument"> The secret argument to be prepended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder PrependQuotedSecret(this ArgumentBuilder builder, IProcessArgument argument) {
+            builder?.PrependQuoted(new SecretArgument(argument));
+            return builder;
+        }
+
+        /// <summary> Appends the specified switch to the argument builder. </summary>
+        /// <param name="builder"> The builder. </param>
+        /// <param name="switch">  The switch preceding the text. </param>
+        /// <param name="text">    The text to be appended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder AppendSwitch(this ArgumentBuilder builder, string @switch, string text) {
+            return AppendSwitch(builder, @switch, " ", text);
+        }
+
+        /// <summary> Prepend the specified switch to the argument builder. </summary>
+        /// <param name="builder"> The builder. </param>
+        /// <param name="switch">  The switch preceding the text. </param>
+        /// <param name="text">    The text to be prepended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder PrependSwitch(this ArgumentBuilder builder, string @switch, string text) {
+            return PrependSwitch(builder, @switch, " ", text);
+        }
+
+        /// <summary> Appends the specified switch to the argument builder. </summary>
+        /// <param name="builder">   The builder. </param>
+        /// <param name="switch">    The switch preceding the text. </param>
+        /// <param name="separator"> The separator between the switch and argument. </param>
+        /// <param name="text">      The text to be appended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder AppendSwitch(this ArgumentBuilder builder, string @switch, string separator, string text) {
+            builder?.Append(new SwitchArgument(@switch, new TextArgument(text), separator));
+            return builder;
+        }
+
+        /// <summary> Prepend the specified switch to the argument builder. </summary>
+        /// <param name="builder">   The builder. </param>
+        /// <param name="switch">    The switch preceding the text. </param>
+        /// <param name="separator"> The separator between the switch and argument. </param>
+        /// <param name="text">      The text to be prepended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder PrependSwitch(this ArgumentBuilder builder, string @switch, string separator, string text) {
+            builder?.Prepend(new SwitchArgument(@switch, new TextArgument(text), separator));
+            return builder;
+        }
+
+        /// <summary> Quotes and appends the specified text to the argument builder. </summary>
+        /// <param name="builder"> The builder. </param>
+        /// <param name="switch">  The switch preceding the text. </param>
+        /// <param name="text">    The text to be quoted and appended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder AppendSwitchQuoted(this ArgumentBuilder builder, string @switch, string text) {
+            return AppendSwitchQuoted(builder, @switch, " ", text);
+        }
+
+        /// <summary> Quotes and prepends the specified text to the argument builder. </summary>
+        /// <param name="builder"> The builder. </param>
+        /// <param name="switch">  The switch preceding the text. </param>
+        /// <param name="text">    The text to be quoted and prepended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder PrependSwitchQuoted(this ArgumentBuilder builder, string @switch, string text) {
+            return PrependSwitchQuoted(builder, @switch, " ", text);
+        }
+
+        /// <summary> Quotes and appends the specified text to the argument builder. </summary>
+        /// <param name="builder">   The builder. </param>
+        /// <param name="switch">    The switch preceding the text. </param>
+        /// <param name="separator"> The separator between the switch and argument. </param>
+        /// <param name="text">      The text to be quoted and appended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder AppendSwitchQuoted(this ArgumentBuilder builder, string @switch, string separator, string text) {
+            builder?.Append(new SwitchArgument(@switch, new QuotedArgument(new TextArgument(text)), separator));
+            return builder;
+        }
+
+        /// <summary> Quotes and prepends the specified text to the argument builder. </summary>
+        /// <param name="builder">   The builder. </param>
+        /// <param name="switch">    The switch preceding the text. </param>
+        /// <param name="separator"> The separator between the switch and argument. </param>
+        /// <param name="text">      The text to be quoted and prepended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder PrependSwitchQuoted(this ArgumentBuilder builder, string @switch, string separator, string text) {
+            builder?.Prepend(new SwitchArgument(@switch, new QuotedArgument(new TextArgument(text)), separator));
+            return builder;
+        }
+
+        /// <summary> Quotes and appends the specified argument to the argument builder. </summary>
+        /// <param name="builder">  The builder. </param>
+        /// <param name="switch">   The switch preceding the text. </param>
+        /// <param name="argument"> The argument to be quoted and appended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder AppendSwitchQuoted(this ArgumentBuilder builder, string @switch, IProcessArgument argument) {
+            return AppendSwitchQuoted(builder, @switch, " ", argument);
+        }
+
+        /// <summary> Quotes and prepends the specified argument to the argument builder. </summary>
+        /// <param name="builder">  The builder. </param>
+        /// <param name="switch">   The switch preceding the text. </param>
+        /// <param name="argument"> The argument to be quoted and prepended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder PrependSwitchQuoted(this ArgumentBuilder builder, string @switch, IProcessArgument argument) {
+            return PrependSwitchQuoted(builder, @switch, " ", argument);
+        }
+
+        /// <summary> Quotes and appends the specified argument to the argument builder. </summary>
+        /// <param name="builder">   The builder. </param>
+        /// <param name="switch">    The switch preceding the text. </param>
+        /// <param name="separator"> The separator between the switch and argument. </param>
+        /// <param name="argument">  The argument to be quoted and appended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder AppendSwitchQuoted(this ArgumentBuilder builder, string @switch, string separator, IProcessArgument argument) {
+            builder?.Append(new SwitchArgument(@switch, new QuotedArgument(argument), separator));
+            return builder;
+        }
+
+        /// <summary> Quotes and prepends the specified argument to the argument builder. </summary>
+        /// <param name="builder">   The builder. </param>
+        /// <param name="switch">    The switch preceding the text. </param>
+        /// <param name="separator"> The separator between the switch and argument. </param>
+        /// <param name="argument">  The argument to be quoted and prepended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder PrependSwitchQuoted(this ArgumentBuilder builder, string @switch, string separator, IProcessArgument argument) {
+            builder?.Prepend(new SwitchArgument(@switch, new QuotedArgument(argument), separator));
+            return builder;
+        }
+
+        /// <summary> Appends the specified secret text to the argument builder. </summary>
+        /// <param name="builder"> The builder. </param>
+        /// <param name="switch">  The switch preceding the text. </param>
+        /// <param name="text">    The secret text to be appended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder AppendSwitchSecret(this ArgumentBuilder builder, string @switch, string text) {
+            return AppendSwitchSecret(builder, @switch, " ", text);
+        }
+
+        /// <summary> Prepend the specified secret text to the argument builder. </summary>
+        /// <param name="builder"> The builder. </param>
+        /// <param name="switch">  The switch preceding the text. </param>
+        /// <param name="text">    The secret text to be prepended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder PrependSwitchSecret(this ArgumentBuilder builder, string @switch, string text) {
+            return PrependSwitchSecret(builder, @switch, " ", text);
+        }
+
+        /// <summary> Appends the specified secret text to the argument builder. </summary>
+        /// <param name="builder">   The builder. </param>
+        /// <param name="switch">    The switch preceding the text. </param>
+        /// <param name="separator"> The separator between the switch and argument. </param>
+        /// <param name="text">      The secret text to be appended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder AppendSwitchSecret(this ArgumentBuilder builder, string @switch, string separator, string text) {
+            builder?.Append(new SwitchArgument(@switch, new SecretArgument(new TextArgument(text)), separator));
+            return builder;
+        }
+
+        /// <summary> Prepend the specified secret text to the argument builder. </summary>
+        /// <param name="builder">   The builder. </param>
+        /// <param name="switch">    The switch preceding the text. </param>
+        /// <param name="separator"> The separator between the switch and argument. </param>
+        /// <param name="text">      The secret text to be prepended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder PrependSwitchSecret(this ArgumentBuilder builder, string @switch, string separator, string text) {
+            builder?.Prepend(new SwitchArgument(@switch, new SecretArgument(new TextArgument(text)), separator));
+            return builder;
+        }
+
+        /// <summary> Appends the specified secret text to the argument builder. </summary>
+        /// <param name="builder">  The builder. </param>
+        /// <param name="switch">   The switch preceding the text. </param>
+        /// <param name="argument"> The secret argument to be appended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder AppendSwitchSecret(this ArgumentBuilder builder, string @switch, IProcessArgument argument) {
+            return AppendSwitchSecret(builder, @switch, " ", argument);
+        }
+
+        /// <summary> Prepend the specified secret text to the argument builder. </summary>
+        /// <param name="builder">  The builder. </param>
+        /// <param name="switch">   The switch preceding the text. </param>
+        /// <param name="argument"> The secret argument to be prepended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder PrependSwitchSecret(this ArgumentBuilder builder, string @switch, IProcessArgument argument) {
+            return PrependSwitchSecret(builder, @switch, " ", argument);
+        }
+
+        /// <summary> Appends the specified secret text to the argument builder. </summary>
+        /// <param name="builder">   The builder. </param>
+        /// <param name="switch">    The switch preceding the text. </param>
+        /// <param name="separator"> The separator between the switch and argument. </param>
+        /// <param name="argument">  The secret argument to be appended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder AppendSwitchSecret(this ArgumentBuilder builder, string @switch, string separator, IProcessArgument argument) {
+            builder?.Append(new SwitchArgument(@switch, new SecretArgument(argument), separator));
+            return builder;
+        }
+
+        /// <summary> Prepend the specified secret text to the argument builder. </summary>
+        /// <param name="builder">   The builder. </param>
+        /// <param name="switch">    The switch preceding the text. </param>
+        /// <param name="separator"> The separator between the switch and argument. </param>
+        /// <param name="argument">  The secret argument to be prepended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder PrependSwitchSecret(this ArgumentBuilder builder, string @switch, string separator, IProcessArgument argument) {
+            builder?.Prepend(new SwitchArgument(@switch, new SecretArgument(argument), separator));
+            return builder;
+        }
+
+        /// <summary> Quotes and appends the specified secret text to the argument builder. </summary>
+        /// <param name="builder"> The builder. </param>
+        /// <param name="switch">  The switch preceding the text. </param>
+        /// <param name="text">    The secret text to be quoted and appended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder AppendSwitchQuotedSecret(this ArgumentBuilder builder, string @switch, string text) {
+            return AppendSwitchQuotedSecret(builder, @switch, " ", text);
+        }
+
+        /// <summary> Quotes and prepend the specified secret text to the argument builder. </summary>
+        /// <param name="builder"> The builder. </param>
+        /// <param name="switch">  The switch preceding the text. </param>
+        /// <param name="text">    The secret text to be quoted and prepended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder PrependSwitchQuotedSecret(this ArgumentBuilder builder, string @switch, string text) {
+            return PrependSwitchQuotedSecret(builder, @switch, " ", text);
+        }
+
+        /// <summary> Quotes and appends the specified secret text to the argument builder. </summary>
+        /// <param name="builder">   The builder. </param>
+        /// <param name="switch">    The switch preceding the text. </param>
+        /// <param name="separator"> The separator between the switch and argument. </param>
+        /// <param name="text">      The secret text to be quoted and appended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder AppendSwitchQuotedSecret(this ArgumentBuilder builder, string @switch, string separator, string text) {
+            builder?.AppendSwitchQuoted(@switch, separator, new SecretArgument(new TextArgument(text)));
+            return builder;
+        }
+
+        /// <summary> Quotes and prepends the specified secret text to the argument builder. </summary>
+        /// <param name="builder">   The builder. </param>
+        /// <param name="switch">    The switch preceding the text. </param>
+        /// <param name="separator"> The separator between the switch and argument. </param>
+        /// <param name="text">      The secret text to be quoted and prepended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder PrependSwitchQuotedSecret(this ArgumentBuilder builder, string @switch, string separator, string text) {
+            builder?.PrependSwitchQuoted(@switch, separator, new SecretArgument(new TextArgument(text)));
+            return builder;
+        }
+
+        /// <summary> Quotes and appends the specified secret text to the argument builder. </summary>
+        /// <param name="builder">  The builder. </param>
+        /// <param name="switch">   The switch preceding the text. </param>
+        /// <param name="argument"> The secret argument to be appended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder AppendQuotedSecret(this ArgumentBuilder builder, string @switch, IProcessArgument argument) {
+            return AppendQuotedSecret(builder, @switch, " ", argument);
+        }
+
+        /// <summary> Quotes and prepends the specified secret text to the argument builder. </summary>
+        /// <param name="builder">  The builder. </param>
+        /// <param name="switch">   The switch preceding the text. </param>
+        /// <param name="argument"> The secret argument to be prepended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder PrependQuotedSecret(this ArgumentBuilder builder, string @switch, IProcessArgument argument) {
+            return PrependQuotedSecret(builder, @switch, " ", argument);
+        }
+
+        /// <summary> Quotes and appends the specified secret text to the argument builder. </summary>
+        /// <param name="builder">   The builder. </param>
+        /// <param name="switch">    The switch preceding the text. </param>
+        /// <param name="separator"> The separator between the switch and argument. </param>
+        /// <param name="argument">  The secret argument to be appended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder AppendQuotedSecret(this ArgumentBuilder builder, string @switch, string separator, IProcessArgument argument) {
+            builder?.AppendSwitchQuoted(@switch, separator, new SecretArgument(argument));
+            return builder;
+        }
+
+        /// <summary> Quotes and prepend the specified secret text to the argument builder. </summary>
+        /// <param name="builder">   The builder. </param>
+        /// <param name="switch">    The switch preceding the text. </param>
+        /// <param name="separator"> The separator between the switch and argument. </param>
+        /// <param name="argument">  The secret argument to be prepended. </param>
+        /// <returns>
+        ///     The same <see cref="ArgumentBuilder"/> instance so that multiple calls can be
+        ///     chained.
+        /// </returns>
+        public static ArgumentBuilder PrependQuotedSecret(this ArgumentBuilder builder, string @switch, string separator, IProcessArgument argument) {
+            builder?.PrependSwitchQuoted(@switch, separator, new SecretArgument(argument));
+            return builder;
+        }
+
+        /// <summary>
+        ///     Indicates whether a <see cref="ArgumentBuilder"/> is null or renders empty.
+        /// </summary>
+        /// <param name="builder"> The builder. </param>
+        /// <returns>
+        ///     <c>true</c> if <paramref name="builder"/> refers to a null or empty
+        ///     <see cref="ArgumentBuilder"/>;
+        ///     <c>false</c> if the <paramref name="builder"/>refers to non null or empty
+        ///     <see cref="ArgumentBuilder"/>
+        /// </returns>
+        public static bool IsNullOrEmpty(this ArgumentBuilder builder) {
+            return builder == null || builder.Count == 0 || string.IsNullOrEmpty(builder.Render());
+        }
+
+        /// <summary>
+        ///     Copies all the arguments of the source <see cref="ArgumentBuilder"/> to target
+        ///     <see cref="ArgumentBuilder"/>.
+        /// </summary>
+        /// <exception cref="ArgumentNullException"> Thrown when one or more required arguments are null. </exception>
+        /// <param name="source"> The argument builder to copy from. </param>
+        /// <param name="target"> The argument builder to copy to. </param>
+        public static void CopyTo(this ArgumentBuilder source, ArgumentBuilder target) {
+            if (source == null) {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            if (target == null) {
+                throw new ArgumentNullException(nameof(target));
+            }
+
+            foreach (var token in source) {
+                target.Append(token);
+            }
+        }
+
+    }
+}

--- a/CliWrap/Argument/ArgumentTypes/QuotedArgument.cs
+++ b/CliWrap/Argument/ArgumentTypes/QuotedArgument.cs
@@ -1,0 +1,39 @@
+﻿
+namespace CliWrap.Argument.ArgumentTypes {
+
+    /// <summary> Represents a quoted argument. </summary>
+    public sealed class QuotedArgument : IProcessArgument {
+
+        private readonly IProcessArgument _argument;
+
+        /// <summary> Initializes a new instance of the <see cref="QuotedArgument"/> class. </summary>
+        /// <param name="argument"> The argument. </param>
+        public QuotedArgument(IProcessArgument argument) {
+            _argument = argument;
+        }
+
+        /// <summary>
+        ///     Render the arguments as a <see cref="string" />. Sensitive information will be
+        ///     included.
+        /// </summary>
+        /// <returns> A string representation of the argument. </returns>
+        public string Render() {
+            return string.Concat("\"", _argument.Render(), "\"");
+        }
+
+        /// <summary>
+        ///     Renders the argument as a <see cref="string" />. Sensitive information will be
+        ///     redacted.
+        /// </summary>
+        /// <returns> A safe string representation of the argument. </returns>
+        public string RenderSafe() {
+            return string.Concat("\"", _argument.RenderSafe(), "\"");
+        }
+
+        /// <summary> Returns a <see cref="string" /> that represents the current object. </summary>
+        /// <returns> A string that represents the current object. </returns>
+        public override string ToString() {
+            return RenderSafe();
+        }
+    }
+}

--- a/CliWrap/Argument/ArgumentTypes/SecretArgument.cs
+++ b/CliWrap/Argument/ArgumentTypes/SecretArgument.cs
@@ -1,0 +1,38 @@
+﻿
+namespace CliWrap.Argument.ArgumentTypes {
+
+    /// <summary> Represents a secret argument. </summary>
+    public sealed class SecretArgument : IProcessArgument {
+
+        private readonly IProcessArgument _argument;
+
+        /// <summary> Initializes a new instance of the <see cref="SecretArgument"/> class. </summary>
+        /// <param name="argument"> The argument. </param>
+        public SecretArgument(IProcessArgument argument) {
+            _argument = argument;
+        }
+
+        /// <summary>
+        ///     Render the arguments as a <see cref="string" />. The secret text will be included.
+        /// </summary>
+        /// <returns> A string representation of the argument. </returns>
+        public string Render() {
+            return _argument.Render();
+        }
+
+        /// <summary>
+        ///     Renders the argument as a <see cref="string" />.
+        ///      The secret text will be redacted.
+        /// </summary>
+        /// <returns> A safe string representation of the argument. </returns>
+        public string RenderSafe() {
+            return "[REDACTED]";
+        }
+
+        /// <summary> Returns a <see cref="string" /> that represents the current object. </summary>
+        /// <returns> A string that represents the current object. </returns>
+        public override string ToString() {
+            return RenderSafe();
+        }
+    }
+}

--- a/CliWrap/Argument/ArgumentTypes/SwitchArgument.cs
+++ b/CliWrap/Argument/ArgumentTypes/SwitchArgument.cs
@@ -1,0 +1,46 @@
+﻿
+namespace CliWrap.Argument.ArgumentTypes {
+
+    /// <summary> Represents a argument preceded by a switch. </summary>
+    public class SwitchArgument : IProcessArgument {
+
+        private readonly string _switch;
+        private readonly IProcessArgument _argument;
+        private readonly string _separator;
+
+        /// <summary> Initializes a new instance of the <see cref="SwitchArgument"/> class. </summary>
+        /// <param name="switch">    The switch. </param>
+        /// <param name="argument">  The argument. </param>
+        /// <param name="separator"> (Optional) The separator between the <paramref name="switch"/> and
+        ///                          the <paramref name="argument"/>. </param>
+        public SwitchArgument(string @switch, IProcessArgument argument, string separator = " ") {
+            _switch = @switch;
+            _argument = argument;
+            _separator = separator;
+        }
+
+        /// <summary>
+        ///     Render the arguments as a <see cref="string" />. Sensitive information will be
+        ///     included.
+        /// </summary>
+        /// <returns> A string representation of the argument. </returns>
+        public string Render() {
+            return string.Concat(_switch, _separator, _argument.Render());
+        }
+
+        /// <summary>
+        ///     Renders the argument as a <see cref="string" />.
+        ///      The secret text will be redacted.
+        /// </summary>
+        /// <returns> A safe string representation of the argument. </returns>
+        public string RenderSafe() {
+            return string.Concat(_switch, _separator, _argument.RenderSafe());
+        }
+
+        /// <summary> Returns a string that represents the current object. </summary>
+        /// <returns> A string that represents the current object. </returns>
+        public override string ToString() {
+            return RenderSafe();
+        }
+    }
+}

--- a/CliWrap/Argument/ArgumentTypes/TextArgument.cs
+++ b/CliWrap/Argument/ArgumentTypes/TextArgument.cs
@@ -1,0 +1,39 @@
+﻿
+namespace CliWrap.Argument.ArgumentTypes {
+
+    /// <summary> Represents a text argument. </summary>
+    public sealed class TextArgument : IProcessArgument {
+
+        private readonly string _text;
+
+        /// <summary> Initializes a new instance of the <see cref="TextArgument"/> class. </summary>
+        /// <param name="text"> The text. </param>
+        public TextArgument(string text) {
+            _text = text;
+        }
+
+        /// <summary>
+        ///     Render the arguments as a <see cref="string" />. Sensitive information will be
+        ///     included.
+        /// </summary>
+        /// <returns> A string representation of the argument. </returns>
+        public string Render() {
+            return _text ?? string.Empty;
+        }
+
+        /// <summary>
+        ///     Renders the argument as a <see cref="string" />. Sensitive information will be
+        ///     redacted.
+        /// </summary>
+        /// <returns> A safe string representation of the argument. </returns>
+        public string RenderSafe() {
+            return Render();
+        }
+
+        /// <summary> Returns a <see cref="string" /> that represents the current object. </summary>
+        /// <returns> A string that represents the current object. </returns>
+        public override string ToString() {
+            return RenderSafe();
+        }
+    }
+}

--- a/CliWrap/Argument/IProcessArgument.cs
+++ b/CliWrap/Argument/IProcessArgument.cs
@@ -1,0 +1,19 @@
+﻿
+namespace CliWrap.Argument {
+
+    /// <summary> Represents a process argument. </summary>
+    public interface IProcessArgument {
+
+        /// <summary>
+        ///     Render the argument as a <see cref="string"/>. Sensitive information will be included.
+        /// </summary>
+        /// <returns> A string representation of the argument. </returns>
+        string Render();
+
+        /// <summary>
+        ///     Renders the argument as a <see cref="string"/>. Sensitive information will be redacted.
+        /// </summary>
+        /// <returns> A safe string representation of the argument. </returns>
+        string RenderSafe();
+    }
+}

--- a/CliWrap/Cli.cs
+++ b/CliWrap/Cli.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using CliWrap.Argument;
 using CliWrap.Exceptions;
 using CliWrap.Internal;
 using CliWrap.Models;
@@ -58,6 +59,13 @@ namespace CliWrap
         public ICli SetArguments(string arguments)
         {
             _arguments = arguments;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public ICli SetArguments(ArgumentBuilder argbuilder)
+        {
+            _arguments = argbuilder.Render();
             return this;
         }
 

--- a/CliWrap/CliWrap.csproj
+++ b/CliWrap/CliWrap.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="ConfigureAwait.Fody" Version="3.1.0" PrivateAssets="all" />
     <PackageReference Include="Fody" Version="4.2.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19554-01" PrivateAssets="all"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19554-01" PrivateAssets="all" />
     <PackageReference Include="Nullable" Version="1.1.1" PrivateAssets="all" />
   </ItemGroup>
 

--- a/CliWrap/ICli.cs
+++ b/CliWrap/ICli.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using CliWrap.Argument;
 using CliWrap.Exceptions;
 using CliWrap.Models;
 
@@ -28,6 +29,10 @@ namespace CliWrap
         /// Sets the command line arguments.
         /// </summary>
         ICli SetArguments(string arguments);
+
+        /// <summary> Sets the command line arguments. </summary>
+        /// <param name="argbuilder"> The ArgumentBuilder to use. </param>
+        ICli SetArguments(ArgumentBuilder argbuilder);
 
         /// <summary>
         /// Sets the command line arguments.


### PR DESCRIPTION
Hi,
I recently added in support for an Argument builder class which might be useful
This is actually a copy / paste from the Cake.IO Sources but it's licenced under MIT so it should be okay

  * https://github.com/cake-build/cake/blob/develop/src/Cake.Core/IO/ProcessArgumentBuilder.cs

So far I've added in a single test to show how it works
although there are other tests that could be copied over, but they use Xunit instead of NUnit which is why I didn't put them in

  * https://github.com/cake-build/cake/blob/develop/src/Cake.Core.Tests/Unit/IO/ProcessArgumentBuilderTests.cs
  * https://github.com/cake-build/cake/blob/develop/src/Cake.Core.Tests/Unit/Extensions/ProcessArgumentListExtensionsTests.cs
