### PR TITLE
Add PipeSource and PipeTarget implementation for native piping directly to/from parent process

### DIFF
--- a/CliWrap/Command.cs
+++ b/CliWrap/Command.cs
@@ -265,7 +265,15 @@ namespace CliWrap
                 {
                     try
                     {
-                        await StandardInputPipe.CopyToAsync(process.StdIn, stdInCts.Token);
+                        // Some streams don't support cancellation, in which case we need a fallback mechanism to avoid deadlocks.
+                        // For example, WindowsConsoleStream (from Console.OpenStandardInput()) in particular doesn't support cancellation.
+                        // In the following case the operation will terminate but a rogue Task will leak and might cause problems.
+                        // This is a non-issue, however, if the user closes the stream at the earliest opportunity.
+                        // Otherwise we enter an indeterminate state and tell ourselves we did everything we could to avoid it.
+                        await Task.WhenAny(
+                            StandardInputPipe.CopyToAsync(process.StdIn, stdInCts.Token),
+                            Task.Delay(-1, stdInCts.Token)
+                        );
                     }
                     // Ignore cancellation here, will propagate later
                     catch (OperationCanceledException)

--- a/CliWrap/Internal/ProcessEx.cs
+++ b/CliWrap/Internal/ProcessEx.cs
@@ -55,9 +55,9 @@ namespace CliWrap.Internal
             StartTime = DateTimeOffset.Now;
 
             Id = _nativeProcess.Id;
-            StdIn = _nativeProcess.StandardInput.BaseStream;
-            StdOut = _nativeProcess.StandardOutput.BaseStream;
-            StdErr = _nativeProcess.StandardError.BaseStream;
+            StdIn = _nativeProcess.StartInfo.RedirectStandardInput ? _nativeProcess.StandardInput.BaseStream : StdIn;
+            StdOut = _nativeProcess.StartInfo.RedirectStandardOutput ? _nativeProcess.StandardOutput.BaseStream : StdOut;
+            StdErr = _nativeProcess.StartInfo.RedirectStandardError ? _nativeProcess.StandardError.BaseStream : StdErr;
         }
 
         public bool TryKill()

--- a/CliWrap/PipeSource.cs
+++ b/CliWrap/PipeSource.cs
@@ -56,6 +56,11 @@ namespace CliWrap
         /// Pipe source that pushes no data.
         /// </summary>
         public static PipeSource Null { get; } = FromStream(Stream.Null);
+
+        /// <summary>
+        /// Pipe source that pipes directly from input stream of parent process.
+        /// </summary>
+        public static PipeSource ParentProcess { get;} = new ParentProcessPipeSource();
     }
 
     internal class StreamPipeSource : PipeSource
@@ -91,5 +96,10 @@ namespace CliWrap
 
         public override async Task CopyToAsync(Stream destination, CancellationToken cancellationToken = default) =>
             await _command.WithStandardOutputPipe(PipeTarget.ToStream(destination)).ExecuteAsync(cancellationToken);
+    }
+
+    internal class ParentProcessPipeSource : PipeSource
+    {
+        public override Task CopyToAsync(Stream destination, CancellationToken cancellationToken = default) => throw new InvalidOperationException("Stream copy operation is not supported from parent process.");
     }
 }

--- a/CliWrap/PipeTarget.cs
+++ b/CliWrap/PipeTarget.cs
@@ -94,12 +94,17 @@ namespace CliWrap
         /// Merges multiple pipe targets into a single one.
         /// Data pushed to this pipe will be replicated for all inner targets.
         /// </summary>
-        public static PipeTarget Merge(params PipeTarget[] targets) => Merge((IEnumerable<PipeTarget>) targets);
+        public static PipeTarget Merge(params PipeTarget[] targets) => Merge((IEnumerable<PipeTarget>)targets);
 
         /// <summary>
         /// Pipe target that ignores all data.
         /// </summary>
         public static PipeTarget Null { get; } = ToStream(Stream.Null);
+
+        /// <summary>
+        /// Pipe target that pipes directly to corresponding output stream (stdout or stderr) of parent process.
+        /// </summary>
+        public static PipeTarget ParentProcess { get; } = new ParentProcessPipeTarget();
     }
 
     internal class StreamPipeTarget : PipeTarget
@@ -224,5 +229,10 @@ namespace CliWrap
             foreach (var subStream in subStreams)
                 await subStream.DisposeAsync();
         }
+    }
+
+    internal class ParentProcessPipeTarget : PipeTarget
+    {
+        public override Task CopyFromAsync(Stream source, CancellationToken cancellationToken = default) => throw new InvalidOperationException("Stream copy operation is not supported to parent process.");
     }
 }


### PR DESCRIPTION
This PR dresses issue #79 by providing an explicit mode whereby streams can be directly piped (using native `Process` functionality) to/from the parent process.

Instead of opening the parent process's streams and creating `StreamPipeSource/StreamPipeTarget`, calling code can use `PipeSource.ParentProcess` and `PipeTarget.ParentProcess` respectively, to indicate that the affected child process stream should be natively piped through to its corresponding parent process counterpart.

Parent process can now do this:

```cs
var cmd =
  Cli.Wrap("git")
    .WithWorkingDirectory(@"/Users/danielrosenberg/Git/StacksTest")
    .WithArguments("mergetool")
    .WithValidation(CommandResultValidation.None)
    .WithStandardInputPipe(PipeSource.ParentProcess)
    .WithStandardOutputPipe(PipeTarget.ParentProcess)
    .WithStandardErrorPipe(PipeTarget.ParentProcess);

var result = await cmd.ExecuteAsync();

var key = Console.ReadKey(intercept: true); // This now works as expected
Console.WriteLine($"Read key: {key.KeyChar}");
```

Just a draft for now to show the basic idea, please let me know what needs to be added to make it an acceptable contribution. I'm guessing test coverage might be one thing.

Fixes #79