### PR TITLE
Fix for PipeTarget.Merge when using large program output buffers

### DIFF
--- a/CliWrap.Tests.Dummy/Program.cs
+++ b/CliWrap.Tests.Dummy/Program.cs
@@ -182,11 +182,12 @@ namespace CliWrap.Tests.Dummy
 
                 [PrintRandomBinary] = args =>
                 {
-                    var count = long.Parse(args.Single(), CultureInfo.InvariantCulture);
+                    var count = long.Parse(args[0], CultureInfo.InvariantCulture);
+                    var bufferSize = args.Length > 1 && long.TryParse(args[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var argBufferSize) ? argBufferSize : 1024;
 
                     using var output = Console.OpenStandardOutput();
 
-                    var buffer = new byte[1024];
+                    var buffer = new byte[bufferSize];
                     var bytesRemaining = count;
 
                     while (bytesRemaining > 0)

--- a/CliWrap/Internal/Extensions/CollectionExtensions.cs
+++ b/CliWrap/Internal/Extensions/CollectionExtensions.cs
@@ -7,11 +7,11 @@ namespace CliWrap.Internal.Extensions
         public static T[] Offset<T>(this T[] arr, int count) =>
             count > 0
                 ? arr.Skip(count).ToArray()
-                : arr;
+                : arr.ToArray();
 
         public static T[] Trim<T>(this T[] arr, int count) =>
             arr.Length > count
                 ? arr.Take(count).ToArray()
-                : arr;
+                : arr.ToArray();
     }
 }


### PR DESCRIPTION
Fixes the real culprit of #81.

I thought the issue was about UTF-8 and handling multi-byte characters, but it isn't. It's actually a general problem where `PipeTarget.Merge` mangles the data when the program's output buffer is larger than CliWrap's (81,920 bytes).

The added test should fail if the `CollectionExtensions` doesn't include the modification.

Fixes #81.