### PR TITLE
Replace manual buffer creation with System.Buffers.ArrayPool

### DIFF
--- a/CliWrap/CliWrap.csproj
+++ b/CliWrap/CliWrap.csproj
@@ -33,6 +33,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net461'">
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.3" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.0" />
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/CliWrap/EventStream/CommandEvent.cs
+++ b/CliWrap/EventStream/CommandEvent.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 
 namespace CliWrap.EventStream
 {

--- a/CliWrap/Internal/Extensions/StreamExtensions.cs
+++ b/CliWrap/Internal/Extensions/StreamExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System.Buffers;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -13,59 +12,45 @@ namespace CliWrap.Internal.Extensions
         public static async Task CopyToAsync(this Stream source, Stream destination, bool autoFlush,
             CancellationToken cancellationToken = default)
         {
-            var buffer = ArrayPool<byte>.Shared.Rent(BufferSizes.Stream);
-            try
-            {
-                int bytesRead;
+            using var buffer = new PooledSharedBuffer<byte>(BufferSizes.Stream);
+            int bytesRead;
 
-                while ((bytesRead = await source.ReadAsync(buffer, cancellationToken)) != 0)
-                {
-                    await destination.WriteAsync(buffer, 0, bytesRead, cancellationToken);
-
-                    if (autoFlush)
-                        await destination.FlushAsync(cancellationToken);
-                }
-            }
-            finally
+            while ((bytesRead = await source.ReadAsync(buffer.Array, cancellationToken)) != 0)
             {
-                ArrayPool<byte>.Shared.Return(buffer);
+                await destination.WriteAsync(buffer.Array, 0, bytesRead, cancellationToken);
+
+                if (autoFlush)
+                    await destination.FlushAsync(cancellationToken);
             }
         }
 
         public static async IAsyncEnumerable<string> ReadAllLinesAsync(this StreamReader reader,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
-            var buffer = ArrayPool<char>.Shared.Rent(BufferSizes.StreamReader);
-            try
-            {
-                int charsRead;
+            using var buffer = new PooledSharedBuffer<char>(BufferSizes.StreamReader);
+            int charsRead;
 
-                var stringBuilder = new StringBuilder();
-                while ((charsRead = await reader.ReadAsync(buffer, cancellationToken)) > 0)
+            var stringBuilder = new StringBuilder();
+            while ((charsRead = await reader.ReadAsync(buffer.Array, cancellationToken)) > 0)
+            {
+                for (var i = 0; i < charsRead; i++)
                 {
-                    for (var i = 0; i < charsRead; i++)
+                    if (buffer.Array[i] == '\n')
                     {
-                        if (buffer[i] == '\n')
-                        {
-                            // Trigger on buffered input (even if it's empty)
-                            yield return stringBuilder.ToString();
-                            stringBuilder.Clear();
-                        }
-                        else if (buffer[i] != '\r')
-                        {
-                            stringBuilder.Append(buffer[i]);
-                        }
+                        // Trigger on buffered input (even if it's empty)
+                        yield return stringBuilder.ToString();
+                        stringBuilder.Clear();
+                    }
+                    else if (buffer.Array[i] != '\r')
+                    {
+                        stringBuilder.Append(buffer.Array[i]);
                     }
                 }
+            }
 
-                // Yield what's remaining
-                if (stringBuilder.Length > 0)
-                    yield return stringBuilder.ToString();
-            }
-            finally
-            {
-                ArrayPool<char>.Shared.Return(buffer);
-            }
+            // Yield what's remaining
+            if (stringBuilder.Length > 0)
+                yield return stringBuilder.ToString();
         }
     }
 }

--- a/CliWrap/Internal/Extensions/StreamExtensions.cs
+++ b/CliWrap/Internal/Extensions/StreamExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Buffers;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -12,46 +13,59 @@ namespace CliWrap.Internal.Extensions
         public static async Task CopyToAsync(this Stream source, Stream destination, bool autoFlush,
             CancellationToken cancellationToken = default)
         {
-            var buffer = new byte[BufferSizes.Stream];
-            int bytesRead;
-
-            while ((bytesRead = await source.ReadAsync(buffer, cancellationToken)) != 0)
+            var buffer = ArrayPool<byte>.Shared.Rent(BufferSizes.Stream);
+            try
             {
-                await destination.WriteAsync(buffer, 0, bytesRead, cancellationToken);
+                int bytesRead;
 
-                if (autoFlush)
-                    await destination.FlushAsync(cancellationToken);
+                while ((bytesRead = await source.ReadAsync(buffer, cancellationToken)) != 0)
+                {
+                    await destination.WriteAsync(buffer, 0, bytesRead, cancellationToken);
+
+                    if (autoFlush)
+                        await destination.FlushAsync(cancellationToken);
+                }
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
             }
         }
 
         public static async IAsyncEnumerable<string> ReadAllLinesAsync(this StreamReader reader,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
-            var stringBuilder = new StringBuilder();
-
-            var buffer = new char[BufferSizes.StreamReader];
-            int charsRead;
-
-            while ((charsRead = await reader.ReadAsync(buffer, cancellationToken)) > 0)
+            var buffer = ArrayPool<char>.Shared.Rent(BufferSizes.StreamReader);
+            try
             {
-                for (var i = 0; i < charsRead; i++)
+                int charsRead;
+
+                var stringBuilder = new StringBuilder();
+                while ((charsRead = await reader.ReadAsync(buffer, cancellationToken)) > 0)
                 {
-                    if (buffer[i] == '\n')
+                    for (var i = 0; i < charsRead; i++)
                     {
-                        // Trigger on buffered input (even if it's empty)
-                        yield return stringBuilder.ToString();
-                        stringBuilder.Clear();
-                    }
-                    else if (buffer[i] != '\r')
-                    {
-                        stringBuilder.Append(buffer[i]);
+                        if (buffer[i] == '\n')
+                        {
+                            // Trigger on buffered input (even if it's empty)
+                            yield return stringBuilder.ToString();
+                            stringBuilder.Clear();
+                        }
+                        else if (buffer[i] != '\r')
+                        {
+                            stringBuilder.Append(buffer[i]);
+                        }
                     }
                 }
-            }
 
-            // Yield what's remaining
-            if (stringBuilder.Length > 0)
-                yield return stringBuilder.ToString();
+                // Yield what's remaining
+                if (stringBuilder.Length > 0)
+                    yield return stringBuilder.ToString();
+            }
+            finally
+            {
+                ArrayPool<char>.Shared.Return(buffer);
+            }
         }
     }
 }

--- a/CliWrap/Internal/PooledArray.cs
+++ b/CliWrap/Internal/PooledArray.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Buffers;
+
+namespace CliWrap.Internal
+{
+    internal struct PooledSharedBuffer<T> : IDisposable
+    {
+        public T[] Array { get; }
+        
+        public PooledSharedBuffer(int minimumLength)
+        {
+            Array = ArrayPool<T>.Shared.Rent(minimumLength);
+        }
+
+        public void Dispose()
+        {
+            ArrayPool<T>.Shared.Return(Array);
+        }
+    }
+}


### PR DESCRIPTION
Related to #83

Running only `BasicBenchmarks`, with 50 randomly generated lines (current benchmark is at 10000 which seems a bit excessive)

Before:
```
BenchmarkDotNet=v0.12.0, OS=Windows 10.0.19041
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.100-rc.1.20452.10
  [Host]     : .NET Core 3.1.8 (CoreCLR 4.700.20.41105, CoreFX 4.700.20.41903), X64 RyuJIT
  DefaultJob : .NET Core 3.1.8 (CoreCLR 4.700.20.41105, CoreFX 4.700.20.41903), X64 RyuJIT


|           Method |     Mean |    Error |   StdDev | Ratio | RatioSD | Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------- |---------:|---------:|---------:|------:|--------:|------:|------:|------:|----------:|
| RunProcessAsTask | 64.92 ms | 1.629 ms | 4.803 ms |  0.79 |    0.06 |     - |     - |     - | 100.58 KB |
|          Sheller | 79.87 ms | 2.502 ms | 7.138 ms |  0.95 |    0.07 |     - |     - |     - | 166.58 KB |
|   MedallionShell | 82.20 ms | 1.629 ms | 2.854 ms |  0.95 |    0.04 |     - |     - |     - | 164.99 KB |
|          CliWrap | 86.41 ms | 1.713 ms | 3.001 ms |  1.00 |    0.00 |     - |     - |     - | 383.38 KB |
```

After:
```
BenchmarkDotNet=v0.12.0, OS=Windows 10.0.19041
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.100-rc.1.20452.10
  [Host]     : .NET Core 3.1.8 (CoreCLR 4.700.20.41105, CoreFX 4.700.20.41903), X64 RyuJIT
  DefaultJob : .NET Core 3.1.8 (CoreCLR 4.700.20.41105, CoreFX 4.700.20.41903), X64 RyuJIT


|           Method |     Mean |    Error |   StdDev | Ratio | RatioSD | Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------- |---------:|---------:|---------:|------:|--------:|------:|------:|------:|----------:|
| RunProcessAsTask | 59.76 ms | 1.191 ms | 1.746 ms |  0.69 |    0.05 |     - |     - |     - | 100.58 KB |
|          Sheller | 72.51 ms | 1.415 ms | 1.182 ms |  0.84 |    0.06 |     - |     - |     - | 166.57 KB |
|          CliWrap | 85.41 ms | 1.707 ms | 4.527 ms |  1.00 |    0.00 |     - |     - |     - | 143.31 KB |
|   MedallionShell | 88.07 ms | 2.151 ms | 6.239 ms |  1.03 |    0.10 |     - |     - |     - | 164.99 KB |
```