### PR TITLE
Lines with leading \r are handled correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,3 +243,6 @@ ModelManifest.xml
 
 # Coverage
 *.opencover.xml
+
+# Rider
+.idea/

--- a/CliWrap.Tests/StreamExtensionsSpecs.cs
+++ b/CliWrap.Tests/StreamExtensionsSpecs.cs
@@ -1,0 +1,152 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using CliWrap.Internal.Extensions;
+using Xunit;
+
+namespace CliWrap.Tests
+{
+    public class StreamExtensionsSpecs
+    {
+        private const string Line1 = nameof(Line1); 
+        private const string Line2 = nameof(Line2); 
+        private const string Line3 = nameof(Line3); 
+        
+        [Fact]
+        public async Task I_can_read_a_stream_with_line_breaks_after_each_line()
+        {
+            // Arrange
+            string content = $"{Line1}\n{Line2}\n";
+            
+            // Act
+            string[] lines = await ReadLines(content);
+            
+            // Assert
+            Assert.Equal(2, lines.Length);
+            Assert.Equal(Line1, lines[0]);
+            Assert.Equal(Line2, lines[1]);
+        }
+
+        [Fact]
+        public async Task I_can_read_a_stream_with_line_breaks_after_each_but_the_last_line()
+        {
+            // Arrange
+            string content = $"{Line1}\n{Line2}";
+            
+            // Act
+            string[] lines = await ReadLines(content);
+            
+            // Assert
+            Assert.Equal(2, lines.Length);
+            Assert.Equal(Line1, lines[0]);
+            Assert.Equal(Line2, lines[1]);
+        }
+        
+        [Fact]
+        public async Task I_can_read_a_stream_with_empty_lines()
+        {
+            // Arrange
+            string content = $"{Line1}\n\n{Line2}";
+            
+            // Act
+            string[] lines = await ReadLines(content);
+            
+            // Assert
+            Assert.Equal(3, lines.Length);
+            Assert.Equal(Line1, lines[0]);
+            Assert.Equal(string.Empty, lines[1]);
+            Assert.Equal(Line2, lines[2]);
+        }
+        
+        [Fact]
+        public async Task I_can_read_a_stream_with_windows_style_line_breaks()
+        {
+            // Arrange
+            string content = $"{Line1}\r\n{Line2}\r\n{Line3}";
+            
+            // Act
+            string[] lines = await ReadLines(content);
+            
+            // Assert
+            Assert.Equal(3, lines.Length);
+            Assert.Equal(Line1, lines[0]);
+            Assert.Equal(Line2, lines[1]);
+            Assert.Equal(Line3, lines[2]);
+        }
+        
+        [Fact]
+        public async Task I_can_read_a_stream_with_windows_style_line_breaks_and_empty_lines()
+        {
+            // Arrange
+            string content = $"{Line1}\r\n\r\n{Line3}";
+            
+            // Act
+            string[] lines = await ReadLines(content);
+            
+            // Assert
+            Assert.Equal(3, lines.Length);
+            Assert.Equal(Line1, lines[0]);
+            Assert.Equal(string.Empty, lines[1]);
+            Assert.Equal(Line3, lines[2]);
+        }
+        
+        [Fact]
+        public async Task I_can_read_a_stream_with_carriage_returns_at_the_start_of_each_line()
+        {
+            // Arrange
+            string content = $"\r{Line1}\r{Line2}\n";
+            
+            // Act
+            string[] lines = await ReadLines(content);
+            
+            // Assert
+            Assert.Equal(2, lines.Length);
+            Assert.Equal(Line1, lines[0]);
+            Assert.Equal(Line2, lines[1]);
+        }
+        
+        [Fact]
+        public async Task I_can_read_a_stream_with_mixed_line_breaks_carriage_returns()
+        {
+            // Arrange
+            const string lineStart = "Download started";
+            const string progress1 = "Progress: 25%";
+            const string progress2 = "Progress: 50%";
+            const string progress3 = "Progress: 75%";
+            const string lineEnd = "Download finished";
+            string content = $"{lineStart}\n" +
+                             $"\r{progress1}" +
+                             $"\r{progress2}" +
+                             $"\r{progress3}\n" +
+                             $"{lineEnd}\n";
+            
+            // Act
+            string[] lines = await ReadLines(content);
+            
+            // Assert
+            Assert.Equal(5, lines.Length);
+            Assert.Equal(lineStart, lines[0]);
+            Assert.Equal(progress1, lines[1]);
+            Assert.Equal(progress2, lines[2]);
+            Assert.Equal(progress3, lines[3]);
+            Assert.Equal(lineEnd, lines[4]);
+        }
+        
+        private static async Task<string[]> ReadLines(string content)
+        {
+            byte[] buffer = Encoding.UTF8.GetBytes(content);
+            var stream = new MemoryStream(buffer);
+            var reader = new StreamReader(stream);
+            
+            var lines = new List<string>();
+            await foreach (string line in reader.ReadAllLinesAsync(CancellationToken.None))
+            {
+                lines.Add(line);
+            }
+
+            return lines.ToArray();
+        }
+    }
+}

--- a/CliWrap/Internal/Extensions/StreamExtensions.cs
+++ b/CliWrap/Internal/Extensions/StreamExtensions.cs
@@ -35,7 +35,8 @@ namespace CliWrap.Internal.Extensions
             // this enables us to convert all of these: "A\r\rB", "A\n\nB" and "A\r\n\r\nB" into 3 lines: "A", "" and "B"
             // if we didn't do this the last example would be converted into 5 lines
             char? lineSeparator = null;
-            
+            bool firstChar = true;
+
             int charsRead;
             while ((charsRead = await reader.ReadAsync(buffer.Array, cancellationToken)) > 0)
             {
@@ -44,8 +45,9 @@ namespace CliWrap.Internal.Extensions
                     char current = buffer.Array[i];
 
                     // if the first char we read is a '\r' we don't return an empty line 
-                    if (current == '\r' && reader.BaseStream.Position == charsRead && i == 0)
+                    if (current == '\r' && firstChar)
                     {
+	                    firstChar = false;
                         continue;
                     }
                     
@@ -65,6 +67,8 @@ namespace CliWrap.Internal.Extensions
                         stringBuilder.Append(current);
                         lineSeparator = null;
                     }
+
+	                firstChar = false;
                 }
             }
 


### PR DESCRIPTION
Fixes https://github.com/Tyrrrz/CliWrap/issues/99.

Sadly the code got a little more complicated than I'd hoped it would be.
I have also written some unit tests to confirm it works correctly.
Before the changes the two unit tests with carriage returns failed, now they work.

I also tried using StreamReader.ReadLineAsync but it returns a bunch of empty lines when working with \r.