### PR TITLE
Add exit code and arguments to CommandExecutionException

### DIFF
--- a/CliWrap.Tests/GeneralSpecs.cs
+++ b/CliWrap.Tests/GeneralSpecs.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using CliWrap.Exceptions;
 using FluentAssertions;
 using Xunit;
 
@@ -61,6 +62,20 @@ namespace CliWrap.Tests
 
             // Act
             await cmd.ExecuteAsync();
+        }
+
+        [Fact(Timeout = 15000)]
+        public async Task Command_with_non_zero_exit_code_yields_exit_code_in_exception()
+        {
+            // Arrange
+            var cmd = Cli.Wrap("dotnet").WithArguments("fail");
+
+            // Act
+            var task = cmd.ExecuteAsync();
+
+            // Assert
+            var ex = await Assert.ThrowsAsync<CommandExecutionException>(async () => await task);
+            ex.ExitCode.Should().Be(1);
         }
     }
 }

--- a/CliWrap.Tests/GeneralSpecs.cs
+++ b/CliWrap.Tests/GeneralSpecs.cs
@@ -65,23 +65,5 @@ namespace CliWrap.Tests
             // Act
             await cmd.ExecuteAsync();
         }
-
-        [Fact(Timeout = 15000)]
-        public async Task Command_with_non_zero_exit_code_yields_exit_code_in_exception()
-        {
-            // Arrange
-          var cmd = Cli.Wrap("dotnet")
-                .WithArguments(a => a
-                    .Add(Dummy.Program.FilePath)
-                    .Add("exit-with")
-                    .Add("--code").Add(1));
-
-            // Act
-            var task = cmd.ExecuteAsync();
-
-            // Assert
-            var ex = await Assert.ThrowsAsync<CommandExecutionException>(async () => await task);
-            ex.ExitCode.Should().Be(1);
-        }
     }
 }

--- a/CliWrap.Tests/GeneralSpecs.cs
+++ b/CliWrap.Tests/GeneralSpecs.cs
@@ -70,8 +70,11 @@ namespace CliWrap.Tests
         public async Task Command_with_non_zero_exit_code_yields_exit_code_in_exception()
         {
             // Arrange
-            var cmd = Cli.Wrap("dotnet")
-                .WithArguments("fail");
+          var cmd = Cli.Wrap("dotnet")
+                .WithArguments(a => a
+                    .Add(Dummy.Program.FilePath)
+                    .Add("exit-with")
+                    .Add("--code").Add(1));
 
             // Act
             var task = cmd.ExecuteAsync();

--- a/CliWrap.Tests/GeneralSpecs.cs
+++ b/CliWrap.Tests/GeneralSpecs.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Text;
 using System.Threading.Tasks;
+using CliWrap.Buffered;
 using CliWrap.Exceptions;
 using FluentAssertions;
 using Xunit;
@@ -68,7 +70,8 @@ namespace CliWrap.Tests
         public async Task Command_with_non_zero_exit_code_yields_exit_code_in_exception()
         {
             // Arrange
-            var cmd = Cli.Wrap("dotnet").WithArguments("fail");
+            var cmd = Cli.Wrap("dotnet")
+                .WithArguments("fail");
 
             // Act
             var task = cmd.ExecuteAsync();

--- a/CliWrap.Tests/ValidationSpecs.cs
+++ b/CliWrap.Tests/ValidationSpecs.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using CliWrap.Buffered;
 using CliWrap.Exceptions;
+using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -55,6 +56,24 @@ namespace CliWrap.Tests
 
             // Act & assert
             await cmd.ExecuteAsync();
+        }
+
+        [Fact(Timeout = 15000)]
+        public async Task Command_with_non_zero_exit_code_yields_exit_code_in_exception()
+        {
+            // Arrange
+            var cmd = Cli.Wrap("dotnet")
+                .WithArguments(a => a
+                    .Add(Dummy.Program.FilePath)
+                    .Add("exit-with")
+                    .Add("--code").Add(1));
+
+            // Act
+            var task = cmd.ExecuteAsync();
+
+            // Assert
+            var ex = await Assert.ThrowsAsync<CommandExecutionException>(async () => await task);
+            ex.ExitCode.Should().Be(1);
         }
     }
 }

--- a/CliWrap/Buffered/BufferedCommandExtensions.cs
+++ b/CliWrap/Buffered/BufferedCommandExtensions.cs
@@ -56,8 +56,7 @@ namespace CliWrap.Buffered
                     if (result.ExitCode != 0 && command.Validation.IsZeroExitCodeValidationEnabled())
                     {
                         throw CommandExecutionException.ExitCodeValidation(
-                            command.TargetFilePath,
-                            command.Arguments,
+                            command,
                             result.ExitCode,
                             result.StandardError.Trim()
                         );

--- a/CliWrap/Command.cs
+++ b/CliWrap/Command.cs
@@ -17,7 +17,7 @@ namespace CliWrap
     /// <summary>
     /// Represents a shell command.
     /// </summary>
-    public partial class Command
+    public partial class Command : ICommandConfiguration
     {
         /// <summary>
         /// File path of the executable, batch file, or script, that this command runs on.
@@ -399,8 +399,7 @@ namespace CliWrap
             if (process.ExitCode != 0 && Validation.IsZeroExitCodeValidationEnabled())
             {
                 throw CommandExecutionException.ExitCodeValidation(
-                    TargetFilePath,
-                    Arguments,
+                    this,
                     process.ExitCode
                 );
             }

--- a/CliWrap/Exceptions/CommandExecutionException.cs
+++ b/CliWrap/Exceptions/CommandExecutionException.cs
@@ -7,10 +7,21 @@ namespace CliWrap.Exceptions
     /// </summary>
     public partial class CommandExecutionException : Exception
     {
+        public string FilePath { get; }
+        public string Arguments { get; }
+        public int ExitCode { get; }
+        public string? StandardError { get; }
+
         /// <summary>
         /// Initializes an instance of <see cref="CommandExecutionException"/>.
         /// </summary>
-        public CommandExecutionException(string message) : base(message) {}
+        public CommandExecutionException(string message, string filePath, string arguments, int exitCode, string? standardError = null) : base(message)
+        {
+            FilePath = filePath;
+            Arguments = arguments;
+            ExitCode = exitCode;
+            StandardError = standardError;
+        }
     }
 
     public partial class CommandExecutionException
@@ -28,7 +39,7 @@ Command:
 
 You can suppress this validation by calling `WithValidation(CommandResultValidation.None)` on the command.".Trim();
 
-            return new CommandExecutionException(message);
+            return new CommandExecutionException(message, filePath, arguments, exitCode);
         }
 
         internal static CommandExecutionException ExitCodeValidation(
@@ -48,7 +59,7 @@ Standard error:
 
 You can suppress this validation by calling `WithValidation(CommandResultValidation.None)` on the command.".Trim();
 
-            return new CommandExecutionException(message);
+            return new CommandExecutionException(message, filePath, arguments, exitCode, standardError);
         }
     }
 }

--- a/CliWrap/Exceptions/CommandExecutionException.cs
+++ b/CliWrap/Exceptions/CommandExecutionException.cs
@@ -11,41 +11,19 @@ namespace CliWrap.Exceptions
         /// Command that triggered the exception.
         /// </summary>
         public ICommandConfiguration Command { get; }
+
         /// <summary>
         /// Exit code returned by the process.
         /// </summary>
         public int ExitCode { get; }
-        public string? StandardError { get; }
 
         /// <summary>
         /// Initializes an instance of <see cref="CommandExecutionException"/>.
         /// </summary>
-        public CommandExecutionException(ICommandConfiguration command, int exitCode, string? standardError = null)
-            : base(BuildMessage(command, exitCode, standardError))
+        public CommandExecutionException(ICommandConfiguration command, int exitCode, string message) : base(message)
         {
             Command = command;
             ExitCode = exitCode;
-            StandardError = standardError;
-        }
-
-        private static string BuildMessage(ICommandConfiguration command, int exitCode, string? standardError)
-        {
-            var message = @$"
-Underlying process reported a non-zero exit code ({exitCode}).
-
-Command:
-  {command.TargetFilePath} {command.Arguments}
-";
-
-            if (standardError != null)
-                message += @$"
-Standard error:
-  {standardError}
-";
-
-            message += Environment.NewLine + "You can suppress this validation by calling `WithValidation(CommandResultValidation.None)` on the command.";
-
-            return message.Trim();
         }
     }
 
@@ -55,7 +33,15 @@ Standard error:
             ICommandConfiguration command,
             int exitCode)
         {
-            return new CommandExecutionException(command, exitCode);
+            var message = @$"
+Underlying process reported a non-zero exit code ({exitCode}).
+
+Command:
+  {command.TargetFilePath} {command.Arguments}
+
+You can suppress this validation by calling `WithValidation(CommandResultValidation.None)` on the command.".Trim();
+
+            return new CommandExecutionException(command, exitCode, message);
         }
 
         internal static CommandExecutionException ExitCodeValidation(
@@ -63,7 +49,18 @@ Standard error:
             int exitCode,
             string standardError)
         {
-            return new CommandExecutionException(command, exitCode, standardError);
+            var message = @$"
+Underlying process reported a non-zero exit code ({exitCode}).
+
+Command:
+  {command.TargetFilePath} {command.Arguments}
+
+Standard error:
+  {standardError}
+
+You can suppress this validation by calling `WithValidation(CommandResultValidation.None)` on the command.".Trim();
+
+            return new CommandExecutionException(command, exitCode, message);
         }
     }
 }

--- a/CliWrap/Exceptions/CommandExecutionException.cs
+++ b/CliWrap/Exceptions/CommandExecutionException.cs
@@ -7,7 +7,13 @@ namespace CliWrap.Exceptions
     /// </summary>
     public partial class CommandExecutionException : Exception
     {
+        /// <summary>
+        /// Command that triggered the exception.
+        /// </summary>
         public ICommandConfiguration Command { get; }
+        /// <summary>
+        /// Exit code returned by the process.
+        /// </summary>
         public int ExitCode { get; }
         public string? StandardError { get; }
 

--- a/CliWrap/ICommandConfiguration.cs
+++ b/CliWrap/ICommandConfiguration.cs
@@ -4,6 +4,9 @@ using System.Text;
 
 namespace CliWrap
 {
+    /// <summary>
+    /// Configuration of a command.
+    /// </summary>
     public interface ICommandConfiguration
     {
         /// <summary>

--- a/CliWrap/ICommandConfiguration.cs
+++ b/CliWrap/ICommandConfiguration.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CliWrap
+{
+    public interface ICommandConfiguration
+    {
+        /// <summary>
+        /// File path of the executable, batch file, or script, that this command runs on.
+        /// </summary>
+        string TargetFilePath { get; }
+
+        /// <summary>
+        /// Arguments passed on the command line.
+        /// </summary>
+        string Arguments { get; }
+
+        /// <summary>
+        /// Working directory path.
+        /// </summary>
+        string WorkingDirPath { get; }
+
+        /// <summary>
+        /// User credentials set for the underlying process.
+        /// </summary>
+        Credentials Credentials { get; }
+
+        /// <summary>
+        /// Environment variables set for the underlying process.
+        /// </summary>
+        IReadOnlyDictionary<string, string> EnvironmentVariables { get; }
+    }
+}


### PR DESCRIPTION
First of all: Thank you for this great library, it really is a big help when dealing with anything on the CLI!

While using it in our project, we have found ourselves disabling the exit code check, just to check the exit code ourselves in order to be able to add the exit code to structured logging, as the `CommandExecutionException` only has a message.

As this is a very simple change, I made this PR to ask if this is a change you would consider instead of asking you to do this. I have also added a very simple test to the generic spec. Please let me know your thoughts, if you would like to have something changed, more tests or any other feedback.