### PR TITLE
Allow environment variables to be set to null to remove them

### DIFF
--- a/CliWrap.Tests/ConfigurationSpecs.cs
+++ b/CliWrap.Tests/ConfigurationSpecs.cs
@@ -133,7 +133,7 @@ namespace CliWrap.Tests
             var cmd = Cli.Wrap("foo").WithEnvironmentVariables(e => e.Set("xxx", "xxx"));
 
             // Act
-            var cmdOther = cmd.WithEnvironmentVariables(new Dictionary<string, string>
+            var cmdOther = cmd.WithEnvironmentVariables(new Dictionary<string, string?>
             {
                 ["name"] = "value",
                 ["key"] = "door"
@@ -142,7 +142,7 @@ namespace CliWrap.Tests
             // Assert
             cmd.Should().BeEquivalentTo(cmdOther, o => o.Excluding(c => c.EnvironmentVariables));
             cmd.EnvironmentVariables.Should().NotBeEquivalentTo(cmdOther.EnvironmentVariables);
-            cmdOther.EnvironmentVariables.Should().BeEquivalentTo(new Dictionary<string, string>
+            cmdOther.EnvironmentVariables.Should().BeEquivalentTo(new Dictionary<string, string?>
             {
                 ["name"] = "value",
                 ["key"] = "door"
@@ -164,7 +164,7 @@ namespace CliWrap.Tests
             // Assert
             cmd.Should().BeEquivalentTo(cmdOther, o => o.Excluding(c => c.EnvironmentVariables));
             cmd.EnvironmentVariables.Should().NotBeEquivalentTo(cmdOther.EnvironmentVariables);
-            cmdOther.EnvironmentVariables.Should().BeEquivalentTo(new Dictionary<string, string>
+            cmdOther.EnvironmentVariables.Should().BeEquivalentTo(new Dictionary<string, string?>
             {
                 ["name"] = "value",
                 ["key"] = "door"

--- a/CliWrap.Tests/EnvironmentSpecs.cs
+++ b/CliWrap.Tests/EnvironmentSpecs.cs
@@ -34,7 +34,7 @@ namespace CliWrap.Tests
         public async Task Command_can_be_executed_with_custom_environment_variables()
         {
             // Arrange
-            var env = new Dictionary<string, string>
+            var env = new Dictionary<string, string?>
             {
                 ["foo"] = "bar",
                 ["hello"] = "world",
@@ -58,6 +58,63 @@ namespace CliWrap.Tests
                 "[hello] = world",
                 "[Path] = there"
             });
+        }
+
+        [Fact(Timeout = 15000)]
+        public async Task Command_can_be_executed_with_null_environment_variables_to_unset_them()
+        {
+            // Arrange
+
+            // Generate unique environment variable names to be used during the test
+            var keyToDelete = "CLIWRAP_TEST_DELETE_" + string.Concat(Guid.NewGuid().ToString().Take(5));
+            var keyToSet = "CLIWRAP_TEST_KEEP_" + string.Concat(Guid.NewGuid().ToString().Take(5));
+
+            var env = new Dictionary<string, string?>
+            {
+                // Stting the variable to null, should remove
+                // the environment variable
+                [keyToDelete] = null,
+
+                [keyToSet] = "value-is-set",
+            };
+
+            // Set the variable in the current environment so that we can verify it is removed
+            Environment.SetEnvironmentVariable(keyToDelete, "value-is-set");
+
+            // Ensure the variable is not set in the current environment
+            Environment.SetEnvironmentVariable(keyToSet, null);
+
+            try
+            {
+                var cmd = Cli.Wrap("dotnet")
+                    .WithArguments(a => a
+                        .Add(Dummy.Program.FilePath)
+                        .Add("print-environment-variables"))
+                    .WithEnvironmentVariables(env);
+
+                // Act
+                var result = await cmd.ExecuteBufferedAsync();
+                var stdOutLines = result.StandardOutput.Split(Environment.NewLine);
+                Array.Sort(stdOutLines);
+
+                // Assert
+                stdOutLines.Should()
+                    .Contain(new[]
+                    {
+                        $"[{keyToSet}] = value-is-set",
+                    })
+                    .And
+                    .NotContain(new[]
+                    {
+                        $"[{keyToDelete}] = value-is-set",
+                    });
+            }
+            finally
+            {
+                // Remove both environment variables by setting them to null
+                Environment.SetEnvironmentVariable(keyToDelete, null);
+                Environment.SetEnvironmentVariable(keyToSet, null);
+            }
         }
     }
 }

--- a/CliWrap/Builders/EnvironmentVariablesBuilder.cs
+++ b/CliWrap/Builders/EnvironmentVariablesBuilder.cs
@@ -8,12 +8,12 @@ namespace CliWrap.Builders
     /// </summary>
     public class EnvironmentVariablesBuilder
     {
-        private readonly IDictionary<string, string> _envVars = new Dictionary<string, string>(StringComparer.Ordinal);
+        private readonly IDictionary<string, string?> _envVars = new Dictionary<string, string?>(StringComparer.Ordinal);
 
         /// <summary>
         /// Sets an environment variable with the specified name to the specified value.
         /// </summary>
-        public EnvironmentVariablesBuilder Set(string name, string value)
+        public EnvironmentVariablesBuilder Set(string name, string? value)
         {
             _envVars[name] = value;
             return this;
@@ -22,6 +22,6 @@ namespace CliWrap.Builders
         /// <summary>
         /// Builds the resulting environment variables.
         /// </summary>
-        public IReadOnlyDictionary<string, string> Build() => new Dictionary<string, string>(_envVars);
+        public IReadOnlyDictionary<string, string?> Build() => new Dictionary<string, string?>(_envVars);
     }
 }

--- a/CliWrap/Command.cs
+++ b/CliWrap/Command.cs
@@ -32,7 +32,7 @@ namespace CliWrap
         public Credentials Credentials { get; }
 
         /// <inheritdoc />
-        public IReadOnlyDictionary<string, string> EnvironmentVariables { get; }
+        public IReadOnlyDictionary<string, string?> EnvironmentVariables { get; }
 
         /// <inheritdoc />
         public CommandResultValidation Validation { get; }
@@ -54,7 +54,7 @@ namespace CliWrap
             string arguments,
             string workingDirPath,
             Credentials credentials,
-            IReadOnlyDictionary<string, string> environmentVariables,
+            IReadOnlyDictionary<string, string?> environmentVariables,
             CommandResultValidation validation,
             PipeSource standardInputPipe,
             PipeTarget standardOutputPipe,
@@ -79,7 +79,7 @@ namespace CliWrap
             string.Empty,
             Directory.GetCurrentDirectory(),
             Credentials.Default,
-            new Dictionary<string, string>(),
+            new Dictionary<string, string?>(),
             CommandResultValidation.ZeroExitCode,
             PipeSource.Null,
             PipeTarget.Null,
@@ -170,7 +170,7 @@ namespace CliWrap
         /// <summary>
         /// Creates a copy of this command, setting the environment variables to the specified value.
         /// </summary>
-        public Command WithEnvironmentVariables(IReadOnlyDictionary<string, string> environmentVariables) => new(
+        public Command WithEnvironmentVariables(IReadOnlyDictionary<string, string?> environmentVariables) => new(
             TargetFilePath,
             Arguments,
             WorkingDirPath,
@@ -285,7 +285,17 @@ namespace CliWrap
             }
 
             foreach (var (key, value) in EnvironmentVariables)
-                result.Environment[key] = value;
+            {
+                // Workaround for https://github.com/dotnet/runtime/issues/34446
+                if (value is null)
+                {
+                    result.Environment.Remove(key);
+                }
+                else
+                {
+                    result.Environment[key] = value;
+                }
+            }
 
             return result;
         }

--- a/CliWrap/ICommandConfiguration.cs
+++ b/CliWrap/ICommandConfiguration.cs
@@ -30,7 +30,7 @@ namespace CliWrap
         /// <summary>
         /// Environment variables set for the underlying process.
         /// </summary>
-        IReadOnlyDictionary<string, string> EnvironmentVariables { get; }
+        IReadOnlyDictionary<string, string?> EnvironmentVariables { get; }
 
         /// <summary>
         /// Configured result validation strategy.


### PR DESCRIPTION
This allows environment variables to be set to null to remove them.
When an environment variable is set to null,
it is removed from the `Process.StartInfo.Environment`

This fixes #109 

And is a workaround for https://github.com/dotnet/runtime/issues/34446 , which I think is fixed in .NET 6.

This is probably a breaking change, because of the nullability change