### PR TITLE
Resolve absolute paths for script files on PATH

### DIFF
--- a/CliWrap/Command.cs
+++ b/CliWrap/Command.cs
@@ -256,7 +256,7 @@ public partial class Command : ICommandConfiguration
     {
         var result = new ProcessStartInfo
         {
-            FileName = TargetFilePath,
+            FileName = PathResolver.ResolvePath(TargetFilePath),
             Arguments = Arguments,
             WorkingDirectory = WorkingDirPath,
             UserName = Credentials.UserName,

--- a/CliWrap/Utils/PathResolver.cs
+++ b/CliWrap/Utils/PathResolver.cs
@@ -1,4 +1,6 @@
 using System;
+using System.IO;
+using System.Runtime.InteropServices;
 
 namespace CliWrap.Utils;
 
@@ -9,7 +11,7 @@ internal static class PathResolver
         // Update target path if necessary
         // We should use 'Path.IsPathFullyQualified', but its not available in .NET Standard 2.0
         // https://github.com/dotnet/runtime/issues/22796
-        if (!PathResolver || Path.IsPathRooted(TargetFilePath)) return fileName;
+        if (Path.IsPathRooted(fileName)) return fileName;
         
         if (File.Exists(fileName))
             return Path.GetFullPath(fileName);

--- a/CliWrap/Utils/PathResolver.cs
+++ b/CliWrap/Utils/PathResolver.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace CliWrap.Utils;
+
+internal static class PathResolver
+{ 
+    internal static string ResolvePath(string fileName)
+    {
+        // Update target path if necessary
+        // We should use 'Path.IsPathFullyQualified', but its not available in .NET Standard 2.0
+        // https://github.com/dotnet/runtime/issues/22796
+        if (!PathResolver || Path.IsPathRooted(TargetFilePath)) return fileName;
+        
+        if (File.Exists(fileName))
+            return Path.GetFullPath(fileName);
+
+        var envValues = Environment.GetEnvironmentVariable("PATH");
+        if (envValues == null) return fileName;
+        foreach (var path in envValues.Split(Path.PathSeparator))
+        {
+            var fullPath = Path.Combine(path, fileName);
+            
+            // we should look for .exe and .cmd files on windows
+            if (!fileName.EndsWith(".exe") && !fileName.EndsWith(".cmd") &&
+                RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                if (File.Exists(fullPath + ".exe"))
+                    return fullPath + ".exe";
+                if (File.Exists(fullPath + ".cmd"))
+                    return fullPath + ".cmd";
+            }
+            else if (File.Exists(fullPath))
+            {
+                return fullPath;
+            }
+        }
+        // If we can't find the file, return the original path
+        return fileName;
+    }
+}
+
+ 


### PR DESCRIPTION
### Details

Hi, 
If you remember we talked about this on your discord channel.

**Problem:**
commands like `npm build` `npx prettier` etc ... Is completely usable in the terminal but can not do the same thing with CLIWrap unless we provide a full target file name.  
Also, If we set a working directory for some reason! sometimes ProcessStartInfo can not find the executable files even on linux.

A real-world project that is using a similar feature using CLIWrap: [husky.net](https://github.com/alirezanet/Husky.Net)

<!-- Please specify the issue addressed by this pull request -->
Closes #133