### PR TITLE
Remove setting of `CreateNoWindow` to reduce overhead

### DIFF
--- a/CliWrap/Command.cs
+++ b/CliWrap/Command.cs
@@ -330,9 +330,7 @@ public partial class Command : ICommandConfiguration
             UserName = Credentials.UserName,
             RedirectStandardInput = true,
             RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true
+            RedirectStandardError = true
         };
 
         // Domain and password are only supported on Windows

--- a/CliWrap/Command.cs
+++ b/CliWrap/Command.cs
@@ -20,6 +20,9 @@ namespace CliWrap;
 /// </summary>
 public partial class Command : ICommandConfiguration
 {
+    [DllImport("kernel32.dll")]
+    private static extern IntPtr GetConsoleWindow();
+
     /// <inheritdoc />
     public string TargetFilePath { get; }
 
@@ -330,8 +333,15 @@ public partial class Command : ICommandConfiguration
             UserName = Credentials.UserName,
             RedirectStandardInput = true,
             RedirectStandardOutput = true,
-            RedirectStandardError = true
+            RedirectStandardError = true,
+            UseShellExecute = false
         };
+
+        // Setting CreateNoWindow has a 30ms overhead added to execution time of the process.
+        // A window won't be created for console applications even when CreateNoWindow = false,
+        // so it's only necessary to set it if there is no console.
+        if (GetConsoleWindow() == IntPtr.Zero)
+            startInfo.CreateNoWindow = true;
 
         // Domain and password are only supported on Windows
         if (Credentials.Domain is not null || Credentials.Password is not null)

--- a/CliWrap/Command.cs
+++ b/CliWrap/Command.cs
@@ -337,6 +337,7 @@ public partial class Command : ICommandConfiguration
         // Setting CreateNoWindow has a 30ms overhead added to execution time of the process.
         // A window won't be created for console applications even when CreateNoWindow = false,
         // so it's only necessary to set it if there is no console.
+        // This check is only necessary on windows platforms because CreateNoWindow does not work on MacOS or Linux.
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && NativeMethods.GetConsoleWindow() == IntPtr.Zero)
             startInfo.CreateNoWindow = true;
 

--- a/CliWrap/Command.cs
+++ b/CliWrap/Command.cs
@@ -20,9 +20,6 @@ namespace CliWrap;
 /// </summary>
 public partial class Command : ICommandConfiguration
 {
-    [DllImport("kernel32.dll")]
-    private static extern IntPtr GetConsoleWindow();
-
     /// <inheritdoc />
     public string TargetFilePath { get; }
 
@@ -340,7 +337,7 @@ public partial class Command : ICommandConfiguration
         // Setting CreateNoWindow has a 30ms overhead added to execution time of the process.
         // A window won't be created for console applications even when CreateNoWindow = false,
         // so it's only necessary to set it if there is no console.
-        if (GetConsoleWindow() == IntPtr.Zero)
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && NativeMethods.GetConsoleWindow() == IntPtr.Zero)
             startInfo.CreateNoWindow = true;
 
         // Domain and password are only supported on Windows

--- a/CliWrap/Command.cs
+++ b/CliWrap/Command.cs
@@ -337,7 +337,8 @@ public partial class Command : ICommandConfiguration
         // Setting CreateNoWindow has a 30ms overhead added to execution time of the process.
         // A window won't be created for console applications even when CreateNoWindow = false,
         // so it's only necessary to set it if there is no console.
-        // This check is only necessary on windows platforms because CreateNoWindow does not work on MacOS or Linux.
+        // This check is only necessary on Windows platforms because CreateNoWindow does not work on MacOS or Linux.
+        // https://github.com/Tyrrrz/CliWrap/pull/142
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && NativeMethods.GetConsoleWindow() == IntPtr.Zero)
             startInfo.CreateNoWindow = true;
 

--- a/CliWrap/Utils/NativeMethods.cs
+++ b/CliWrap/Utils/NativeMethods.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-namespace CliWrap.Utils
+namespace CliWrap.Utils;
+
+internal static class NativeMethods
 {
-    internal static class NativeMethods
-    {
-        [DllImport("kernel32.dll")]
-        public static extern IntPtr GetConsoleWindow();
-    }
+    [DllImport("kernel32.dll")]
+    public static extern IntPtr GetConsoleWindow();
 }

--- a/CliWrap/Utils/NativeMethods.cs
+++ b/CliWrap/Utils/NativeMethods.cs
@@ -5,10 +5,6 @@ namespace CliWrap.Utils
 {
     internal static class NativeMethods
     {
-        /// <summary>
-        /// Returns a pointer to the console window.
-        /// </summary>
-        /// <returns>Pointer to the console window, IntPtr.Zero if there is no console.</returns>
         [DllImport("kernel32.dll")]
         public static extern IntPtr GetConsoleWindow();
     }

--- a/CliWrap/Utils/NativeMethods.cs
+++ b/CliWrap/Utils/NativeMethods.cs
@@ -3,8 +3,15 @@ using System.Runtime.InteropServices;
 
 namespace CliWrap.Utils
 {
+    /// <summary>
+    /// DLL imports for windows-specific APIs.
+    /// </summary>
     internal static class NativeMethods
     {
+        /// <summary>
+        /// Returns a pointer to the console window.
+        /// </summary>
+        /// <returns>Pointer to the console window, IntPtr.Zero if there is no console.</returns>
         [DllImport("kernel32.dll")]
         public static extern IntPtr GetConsoleWindow();
     }

--- a/CliWrap/Utils/NativeMethods.cs
+++ b/CliWrap/Utils/NativeMethods.cs
@@ -3,9 +3,6 @@ using System.Runtime.InteropServices;
 
 namespace CliWrap.Utils
 {
-    /// <summary>
-    /// DLL imports for windows-specific APIs.
-    /// </summary>
     internal static class NativeMethods
     {
         /// <summary>

--- a/CliWrap/Utils/NativeMethods.cs
+++ b/CliWrap/Utils/NativeMethods.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace CliWrap.Utils
+{
+    internal static class NativeMethods
+    {
+        [DllImport("kernel32.dll")]
+        public static extern IntPtr GetConsoleWindow();
+    }
+}


### PR DESCRIPTION
I've observed a 30-40ms overhead added to the execution time of any process when you set ProcessStartInfo.CreateNoWindow to anything, true or false. I'm not sure why exactly this is, but you can see the difference in the benchmarks really easily. CliWrap sets CreateNoWindow = true and UseShellExecute = false. But as far as I can tell, UseShellExecute = false is the default and CreateNoWindow doesn't work unless UseShellExecute = true. So removing those two settings from the ProcessStartInfo is functionally equivalent to the way they are currently, but it allows processes to run without the 30ms overhead. 