### PR TITLE
Add a method to construct `PipeSource` from delegate

### DIFF
--- a/CliWrap.Tests/PipingSpecs.cs
+++ b/CliWrap.Tests/PipingSpecs.cs
@@ -43,7 +43,7 @@ public class PipingSpecs : IClassFixture<TempOutputFixture>
     public async Task Stdin_can_be_piped_from_stream_synchronous_delegate()
     {
         // Arrange
-        var source = PipeSource.FromDelegate(stream =>
+        var source = PipeSource.Create(stream =>
         {
             using var writer = new StreamWriter(stream);
             writer.Write("Hello world!");
@@ -65,7 +65,7 @@ public class PipingSpecs : IClassFixture<TempOutputFixture>
     public async Task Stdin_can_be_piped_from_stream_asynchronous_delegate()
     {
         // Arrange
-        var source = PipeSource.FromDelegate(async (stream, _) =>
+        var source = PipeSource.Create(async (stream, _) =>
         {
             await using var writer = new StreamWriter(stream);
             await writer.WriteAsync("Hello world!");
@@ -87,7 +87,7 @@ public class PipingSpecs : IClassFixture<TempOutputFixture>
     public async Task Stdin_can_be_piped_from_text_writer_synchronous_delegate()
     {
         // Arrange
-        var source = PipeSource.FromDelegate(writer => writer.Write("Hello world!"));
+        var source = PipeSource.Create(writer => writer.Write("Hello world!"));
 
         var cmd = source | Cli.Wrap("dotnet")
             .WithArguments(a => a
@@ -105,7 +105,7 @@ public class PipingSpecs : IClassFixture<TempOutputFixture>
     public async Task Stdin_can_be_piped_from_text_writer_asynchronous_delegate()
     {
         // Arrange
-        var source = PipeSource.FromDelegate(async (writer, _) => await writer.WriteAsync("Hello world!"));
+        var source = PipeSource.Create(async (writer, _) => await writer.WriteAsync("Hello world!"));
 
         var cmd = source | Cli.Wrap("dotnet")
             .WithArguments(a => a

--- a/CliWrap.Tests/PipingSpecs.cs
+++ b/CliWrap.Tests/PipingSpecs.cs
@@ -40,6 +40,50 @@ public class PipingSpecs : IClassFixture<TempOutputFixture>
     }
 
     [Fact(Timeout = 15000)]
+    public async Task Stdin_can_be_piped_from_stream_synchronous_delegate()
+    {
+        // Arrange
+        var source = PipeSource.FromDelegate(stream =>
+        {
+            using var writer = new StreamWriter(stream);
+            writer.Write("Hello world!");
+        });
+
+        var cmd = source | Cli.Wrap("dotnet")
+            .WithArguments(a => a
+                .Add(Dummy.Program.FilePath)
+                .Add("echo-stdin"));
+
+        // Act
+        var result = await cmd.ExecuteBufferedAsync();
+
+        // Assert
+        result.StandardOutput.Should().Be("Hello world!");
+    }
+
+    [Fact(Timeout = 15000)]
+    public async Task Stdin_can_be_piped_from_stream_asynchronous_delegate()
+    {
+        // Arrange
+        var source = PipeSource.FromDelegate(async (stream, _) =>
+        {
+            await using var writer = new StreamWriter(stream);
+            await writer.WriteAsync("Hello world!");
+        });
+
+        var cmd = source | Cli.Wrap("dotnet")
+            .WithArguments(a => a
+                .Add(Dummy.Program.FilePath)
+                .Add("echo-stdin"));
+
+        // Act
+        var result = await cmd.ExecuteBufferedAsync();
+
+        // Assert
+        result.StandardOutput.Should().Be("Hello world!");
+    }
+
+    [Fact(Timeout = 15000)]
     public async Task Stdin_can_be_piped_from_text_writer_synchronous_delegate()
     {
         // Arrange
@@ -61,7 +105,7 @@ public class PipingSpecs : IClassFixture<TempOutputFixture>
     public async Task Stdin_can_be_piped_from_text_writer_asynchronous_delegate()
     {
         // Arrange
-        var source = PipeSource.FromDelegate(async writer => await writer.WriteAsync("Hello world!"));
+        var source = PipeSource.FromDelegate(async (writer, _) => await writer.WriteAsync("Hello world!"));
 
         var cmd = source | Cli.Wrap("dotnet")
             .WithArguments(a => a

--- a/CliWrap.Tests/PipingSpecs.cs
+++ b/CliWrap.Tests/PipingSpecs.cs
@@ -40,6 +40,42 @@ public class PipingSpecs : IClassFixture<TempOutputFixture>
     }
 
     [Fact(Timeout = 15000)]
+    public async Task Stdin_can_be_piped_from_text_writer_synchronous_delegate()
+    {
+        // Arrange
+        var source = PipeSource.FromDelegate(writer => writer.Write("Hello world!"));
+
+        var cmd = source | Cli.Wrap("dotnet")
+            .WithArguments(a => a
+                .Add(Dummy.Program.FilePath)
+                .Add("echo-stdin"));
+
+        // Act
+        var result = await cmd.ExecuteBufferedAsync();
+
+        // Assert
+        result.StandardOutput.Should().Be("Hello world!");
+    }
+
+    [Fact(Timeout = 15000)]
+    public async Task Stdin_can_be_piped_from_text_writer_asynchronous_delegate()
+    {
+        // Arrange
+        var source = PipeSource.FromDelegate(async writer => await writer.WriteAsync("Hello world!"));
+
+        var cmd = source | Cli.Wrap("dotnet")
+            .WithArguments(a => a
+                .Add(Dummy.Program.FilePath)
+                .Add("echo-stdin"));
+
+        // Act
+        var result = await cmd.ExecuteBufferedAsync();
+
+        // Assert
+        result.StandardOutput.Should().Be("Hello world!");
+    }
+
+    [Fact(Timeout = 15000)]
     public async Task Stdin_can_be_piped_from_a_file()
     {
         // Arrange

--- a/CliWrap/CliWrap.csproj
+++ b/CliWrap/CliWrap.csproj
@@ -27,7 +27,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="IsExternalInit" Version="1.0.2" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
     <PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="all" />
   </ItemGroup>

--- a/CliWrap/CliWrap.csproj
+++ b/CliWrap/CliWrap.csproj
@@ -27,6 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="IsExternalInit" Version="1.0.2" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
     <PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="all" />
   </ItemGroup>

--- a/CliWrap/PipeSource.cs
+++ b/CliWrap/PipeSource.cs
@@ -71,24 +71,24 @@ public partial class PipeSource
     /// <summary>
     /// Creates a pipe source that reads from a synchronous delegate that writes to a <see cref="Stream"/>.
     /// </summary>
-    public static PipeSource FromDelegate(Action<Stream> source) => new StreamDelegatePipeSource(source);
+    public static PipeSource Create(Action<Stream> source) => new AnonymousPipeSource(source);
 
     /// <summary>
     /// Creates a pipe source that reads from an asynchronous delegate that writes to a <see cref="Stream"/>.
     /// </summary>
-    public static PipeSource FromDelegate(Func<Stream, CancellationToken, Task> source) => new StreamAsyncDelegatePipeSource(source);
+    public static PipeSource Create(Func<Stream, CancellationToken, Task> source) => new AsyncAnonymousPipeSource(source);
 
     /// <summary>
     /// Creates a pipe source that reads from a synchronous delegate that writes to a <see cref="TextWriter"/>.
     /// </summary>
-    public static PipeSource FromDelegate(Action<TextWriter> source, Encoding? encoding = null, int bufferSize = -1, bool autoFlush = false) =>
-        new TextWriterDelegatePipeSource(source, encoding ?? Console.InputEncoding, bufferSize, autoFlush);
+    public static PipeSource Create(Action<TextWriter> source, Encoding? encoding = null, int bufferSize = -1, bool autoFlush = false) =>
+        new TextWriterAnonymousPipeSource(source, encoding ?? Console.InputEncoding, bufferSize, autoFlush);
 
     /// <summary>
     /// Creates a pipe source that reads from an asynchronous delegate that writes to a <see cref="TextWriter"/>.
     /// </summary>
-    public static PipeSource FromDelegate(Func<TextWriter, CancellationToken, Task> source, Encoding? encoding = null, int bufferSize = -1, bool autoFlush = false) =>
-        new TextWriterAsyncDelegatePipeSource(source, encoding ?? Console.InputEncoding, bufferSize, autoFlush);
+    public static PipeSource Create(Func<TextWriter, CancellationToken, Task> source, Encoding? encoding = null, int bufferSize = -1, bool autoFlush = false) =>
+        new TextWriterAsyncAnonymousPipeSource(source, encoding ?? Console.InputEncoding, bufferSize, autoFlush);
 }
 
 internal class NullPipeSource : PipeSource
@@ -154,11 +154,11 @@ internal class CommandPipeSource : PipeSource
             .ConfigureAwait(false);
 }
 
-internal class StreamDelegatePipeSource : PipeSource
+internal class AnonymousPipeSource : PipeSource
 {
     private readonly Action<Stream> _source;
 
-    public StreamDelegatePipeSource(Action<Stream> source) => _source = source;
+    public AnonymousPipeSource(Action<Stream> source) => _source = source;
 
     public override Task CopyToAsync(Stream destination, CancellationToken cancellationToken = default)
     {
@@ -167,24 +167,24 @@ internal class StreamDelegatePipeSource : PipeSource
     }
 }
 
-internal class StreamAsyncDelegatePipeSource : PipeSource
+internal class AsyncAnonymousPipeSource : PipeSource
 {
     private readonly Func<Stream, CancellationToken, Task> _source;
 
-    public StreamAsyncDelegatePipeSource(Func<Stream, CancellationToken, Task> source) => _source = source;
+    public AsyncAnonymousPipeSource(Func<Stream, CancellationToken, Task> source) => _source = source;
 
     public override async Task CopyToAsync(Stream destination, CancellationToken cancellationToken = default) =>
         await _source(destination, cancellationToken).ConfigureAwait(false);
 }
 
-internal class TextWriterDelegatePipeSource : PipeSource
+internal class TextWriterAnonymousPipeSource : PipeSource
 {
     private readonly Action<TextWriter> _source;
     private readonly Encoding _encoding;
     private readonly int _bufferSize;
     private readonly bool _autoFlush;
 
-    public TextWriterDelegatePipeSource(Action<TextWriter> source, Encoding encoding, int bufferSize, bool autoFlush)
+    public TextWriterAnonymousPipeSource(Action<TextWriter> source, Encoding encoding, int bufferSize, bool autoFlush)
     {
         _source = source;
         _encoding = encoding;
@@ -203,14 +203,14 @@ internal class TextWriterDelegatePipeSource : PipeSource
     }
 }
 
-internal class TextWriterAsyncDelegatePipeSource : PipeSource
+internal class TextWriterAsyncAnonymousPipeSource : PipeSource
 {
     private readonly Func<TextWriter, CancellationToken, Task> _source;
     private readonly Encoding _encoding;
     private readonly int _bufferSize;
     private readonly bool _autoFlush;
 
-    public TextWriterAsyncDelegatePipeSource(Func<TextWriter, CancellationToken, Task> source, Encoding encoding, int bufferSize, bool autoFlush)
+    public TextWriterAsyncAnonymousPipeSource(Func<TextWriter, CancellationToken, Task> source, Encoding encoding, int bufferSize, bool autoFlush)
     {
         _source = source;
         _encoding = encoding;


### PR DESCRIPTION
A real-world usage would be piping the construction of a [DotGraph][1] object to the `dot` command line tool like this:

```c#
Cli.Wrap("dot").WithStandardInputPipe(PipeSource.FromDelegate(writer => graph.Build(writer)));
```

✊🇺🇦

[1]: https://github.com/mariusz-schimke/GiGraph