### PR TITLE
Add support for sensitive arguments and environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ bld/
 
 # Coverage
 *.opencover.xml
+
+# Visual Studio cache/options directory
+.vs/

--- a/CliWrap.Tests.Dummy/Commands/PrintArgsCommand.cs
+++ b/CliWrap.Tests.Dummy/Commands/PrintArgsCommand.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using CliFx;
+using CliFx.Attributes;
+using CliFx.Infrastructure;
+
+namespace CliWrap.Tests.Dummy.Commands;
+
+[Command("print-args")]
+public class PrintArgsCommand : ICommand
+{
+    [CommandParameter(0)]
+    public IReadOnlyList<string> Parameters { get; init; } = Array.Empty<string>();
+
+    public async ValueTask ExecuteAsync(IConsole console)
+    {
+        var args = Environment.GetCommandLineArgs();
+        for (int i = 0; i < args.Length; i++)
+        {
+            await console.Output.WriteLineAsync($"[{i}] = {args[i]}");
+        }
+    }
+}

--- a/CliWrap/Builders/EnvironmentVariablesBuilder.cs
+++ b/CliWrap/Builders/EnvironmentVariablesBuilder.cs
@@ -8,12 +8,28 @@ namespace CliWrap.Builders;
 /// </summary>
 public class EnvironmentVariablesBuilder
 {
-    private readonly IDictionary<string, string?> _envVars = new Dictionary<string, string?>(StringComparer.Ordinal);
+    private readonly IDictionary<string, SensitiveString?> _envVars = new Dictionary<string, SensitiveString?>(StringComparer.Ordinal);
 
     /// <summary>
     /// Sets an environment variable with the specified name to the specified value.
     /// </summary>
     public EnvironmentVariablesBuilder Set(string name, string? value)
+    {
+        return Set(name, new SensitiveString(value, value ?? string.Empty));
+    }
+
+    /// <summary>
+    /// Sets an environment variable with the specified name to the specified sensitive value.
+    /// </summary>
+    public EnvironmentVariablesBuilder Set(string name, string? value, string mask)
+    {
+        return Set(name, new SensitiveString(value, mask));
+    }
+
+    /// <summary>
+    /// Sets an environment variable with the specified name to the specified sensitive value.
+    /// </summary>
+    public EnvironmentVariablesBuilder Set(string name, SensitiveString value)
     {
         _envVars[name] = value;
         return this;
@@ -25,7 +41,9 @@ public class EnvironmentVariablesBuilder
     public EnvironmentVariablesBuilder Set(IEnumerable<KeyValuePair<string, string?>> variables)
     {
         foreach (var (name, value) in variables)
+        {
             Set(name, value);
+        }
 
         return this;
     }
@@ -39,5 +57,5 @@ public class EnvironmentVariablesBuilder
     /// <summary>
     /// Builds the resulting environment variables.
     /// </summary>
-    public IReadOnlyDictionary<string, string?> Build() => new Dictionary<string, string?>(_envVars);
+    public IReadOnlyDictionary<string, SensitiveString?> Build() => new Dictionary<string, SensitiveString?>(_envVars);
 }

--- a/CliWrap/CliWrap.csproj
+++ b/CliWrap/CliWrap.csproj
@@ -19,6 +19,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
     <PublicSign>false</PublicSign>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CliWrap/ICommandConfiguration.cs
+++ b/CliWrap/ICommandConfiguration.cs
@@ -15,7 +15,7 @@ public interface ICommandConfiguration
     /// <summary>
     /// Arguments passed on the command line.
     /// </summary>
-    string Arguments { get; }
+    SensitiveString Arguments { get; }
 
     /// <summary>
     /// Working directory path set for the underlying process.
@@ -30,7 +30,7 @@ public interface ICommandConfiguration
     /// <summary>
     /// Environment variables set for the underlying process.
     /// </summary>
-    IReadOnlyDictionary<string, string?> EnvironmentVariables { get; }
+    IReadOnlyDictionary<string, SensitiveString?> EnvironmentVariables { get; }
 
     /// <summary>
     /// Configured result validation strategy.

--- a/CliWrap/SecureStringHelper.cs
+++ b/CliWrap/SecureStringHelper.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Security;
+
+namespace CliWrap;
+
+internal class SecureStringHelper
+{
+    internal static string? MarshalToString(SecureString input)
+    {
+        Debug.Assert(input != null, nameof(input) + " != null");
+        if (input.Length == 0)
+        {
+            return string.Empty;
+        }
+        var ptr = IntPtr.Zero;
+        string? result;
+        try
+        {
+            ptr = Marshal.SecureStringToGlobalAllocUnicode(input);
+            result = Marshal.PtrToStringUni(ptr);
+        }
+        finally
+        {
+            if (ptr != IntPtr.Zero)
+            {
+                Marshal.ZeroFreeGlobalAllocUnicode(ptr);
+            }
+        }
+        return result;
+    }
+
+    internal static unsafe SecureString MarshalToSecureString(string? input)
+    {
+        if (string.IsNullOrEmpty(input))
+        {
+            return new SecureString();
+        }
+        fixed (char* ptr = input)
+        {
+            return new SecureString(ptr, input.Length);
+        }
+    }
+}

--- a/CliWrap/SensitiveString.cs
+++ b/CliWrap/SensitiveString.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Security;
+
+namespace CliWrap
+{
+    /// <summary>
+    /// Represents a command parameter that should be kept confidential.
+    /// A masked value will appear in all sensitive output (such as logging).
+    /// </summary>
+    public sealed class SensitiveString : IDisposable
+    {
+        internal const string DefaultMask = "*****";
+        private SecureString _value;
+        private string _mask;
+        private bool _disposed;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref='SensitiveString'/> class with value and default mask.
+        /// </summary>
+        /// <param name="value">The sensitive value.</param>
+        public SensitiveString(string? value) : this(value, DefaultMask)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref='SensitiveString'/> class with value and default mask.
+        /// </summary>
+        /// <param name="value">The sensitive value.</param>
+        public SensitiveString(SecureString value) : this(value, DefaultMask)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref='SensitiveString'/> class with value and mask.
+        /// </summary>
+        /// <param name="value">The sensitive value.</param>
+        /// <param name="mask">The mask value.</param>
+        public SensitiveString(string? value, string mask) : this(SecureStringHelper.MarshalToSecureString(value), mask)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref='SensitiveString'/> class with value and mask.
+        /// </summary>
+        /// <param name="value">The sensitive value.</param>
+        /// /// <param name="mask">The mask value.</param>
+        public SensitiveString(SecureString value, string mask)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+            if (mask == null)
+            {
+                throw new ArgumentNullException(nameof(mask));
+            }
+            _value = value;
+            _mask = mask;
+        }
+
+        /// <summary>
+        /// Returns the string representation of the object.
+        /// </summary>
+        /// <param name="value">The <see cref='SensitiveString'/> value.</param>
+        /// <returns>The mask value.</returns>
+        [return: NotNullIfNotNull("value")]
+        public static implicit operator string?(SensitiveString? value)
+        {
+            return value?.ToString();
+        }
+        
+        /// <summary>
+        /// Returns the masked value of the current object.
+        /// </summary>
+        /// <returns>The mask value.</returns>
+        public override string ToString()
+        {
+            GuardNotDisposed();
+            return _mask;
+        }
+        
+        internal string? UnsecureString
+        {
+            get
+            {
+                GuardNotDisposed();
+                return SecureStringHelper.MarshalToString(_value);
+            }
+        }
+
+        private void GuardNotDisposed()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(SensitiveString));
+            }
+        }
+        
+        /// <summary>
+        /// Releases all resources used by the current <see cref='SensitiveString'/> object.
+        /// </summary>
+        public void Dispose()
+        {
+            _value.Dispose();
+            _disposed = true;
+        }
+    }
+}


### PR DESCRIPTION
Sensitive parameters can currently be exposed in command details and exception details. 
Added SensitiveString class to ensure this information is not exposed in logging or exception details