### PR TITLE
Add WithExitCondition feature

### DIFF
--- a/CliWrap.Tests.Dummy/Commands/RunProcessCommand.cs
+++ b/CliWrap.Tests.Dummy/Commands/RunProcessCommand.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using CliFx;
+using CliFx.Attributes;
+using CliFx.Infrastructure;
+
+namespace CliWrap.Tests.Dummy.Commands;
+
+[Command("run process")]
+public class RunProcessCommand : ICommand
+{
+    [CommandOption("path")]
+    public string FilePath { get; init; } = string.Empty;
+
+    [CommandOption("arguments")]
+    public string Arguments { get; init; } = string.Empty;
+
+    public ValueTask ExecuteAsync(IConsole console)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = FilePath,
+            Arguments = Arguments,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        var process = new Process();
+        process.StartInfo = startInfo;
+        process.Start();
+
+        console.Output.WriteLine(process.Id);
+
+        return default;
+    }
+}

--- a/CliWrap.Tests/ExitConditionSpecs.cs
+++ b/CliWrap.Tests/ExitConditionSpecs.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace CliWrap.Tests;
+
+public class ExitConditionSpecs()
+{
+    [Fact(Timeout = 15000)]
+    public async Task I_can_execute_a_command_that_creates_child_process_resuing_standard_output_and_finish_after_child_process_exits()
+    {
+        // Arrange
+        var cmd = this.PrepareCommand(line => { });
+
+        // Act
+        var executionStart = DateTime.UtcNow;
+        var result = await cmd.ExecuteAsync();
+        var executionFinish = DateTime.UtcNow;
+
+        // Assert
+        executionFinish
+            .Subtract(executionStart)
+            .Should()
+            .BeGreaterThanOrEqualTo(TimeSpan.FromSeconds(3));
+    }
+
+    [Fact(Timeout = 15000)]
+    public async Task I_can_execute_a_command_that_creates_child_process_resuing_standard_output_and_finish_instantly_after_main_process_exits()
+    {
+        // Arrange
+        int childProcessId = -1;
+        var cmd = this.PrepareCommand(line => childProcessId = Convert.ToInt32(line.Trim()))
+            .WithExitCondition(CommandExitCondition.ProcessExited);
+
+        // Act
+        var executionStart = DateTime.UtcNow;
+        var result = await cmd.ExecuteAsync();
+        var executionFinish = DateTime.UtcNow;
+
+        var process = Process.GetProcessById(childProcessId);
+
+        // Assert
+        executionFinish.Subtract(executionStart).Should().BeLessThan(TimeSpan.FromSeconds(3));
+
+        process.HasExited.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// Prepares a command that will create a sleeping child process and return its id via standard output.
+    /// </summary>
+    private Command PrepareCommand(Action<string> onStandardOutput)
+    {
+        var cmd = Cli.Wrap(Dummy.Program.FilePath)
+            .WithArguments(
+                [
+                    "run",
+                    "process",
+                    "--path",
+                    Dummy.Program.FilePath,
+                    "--arguments",
+                    "sleep 00:00:03"
+                ]
+            )
+            .WithStandardOutputPipe(PipeTarget.ToDelegate(line => onStandardOutput(line)))
+            .WithStandardErrorPipe(
+                PipeTarget.ToDelegate(line => Console.WriteLine($"Error: {line}"))
+            );
+
+        return cmd;
+    }
+}

--- a/CliWrap/Command.Execution.cs
+++ b/CliWrap/Command.Execution.cs
@@ -245,7 +245,7 @@ public partial class Command
             // If the pipe is still trying to transfer data, this will cause it to abort.
             await stdInCts.CancelAsync();
 
-            if (WaitForOutputProcessing)
+            if (CommandExitCondition == CommandExitCondition.PipesClosed)
             {
                 // Wait until piping is done and propagate exceptions
                 await pipingTask.ConfigureAwait(false);

--- a/CliWrap/Command.Execution.cs
+++ b/CliWrap/Command.Execution.cs
@@ -247,8 +247,17 @@ public partial class Command
 
             if (CommandExitCondition == CommandExitCondition.PipesClosed)
             {
-                // Wait until piping is done and propagate exceptions
-                await pipingTask.ConfigureAwait(false);
+                try
+                {
+                    // Wait until piping is done and propagate exceptions
+                    await pipingTask.ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    // throw original token if it was the source of cancel
+                    forcefulCancellationToken.ThrowIfCancellationRequested();
+                    throw;
+                }
             }
             else if (CommandExitCondition == CommandExitCondition.ProcessExited)
             {

--- a/CliWrap/Command.Execution.cs
+++ b/CliWrap/Command.Execution.cs
@@ -250,7 +250,7 @@ public partial class Command
                 // Wait until piping is done and propagate exceptions
                 await pipingTask.ConfigureAwait(false);
             }
-            else
+            else if (CommandExitCondition == CommandExitCondition.ProcessExited)
             {
                 try
                 {
@@ -259,6 +259,10 @@ public partial class Command
                     await pipingTask.ConfigureAwait(false);
                 }
                 catch (OperationCanceledException) { }
+            }
+            else
+            {
+                throw new NotImplementedException($"{CommandExitCondition} is not implemented.");
             }
         }
         // Swallow exceptions caused by internal and user-provided cancellations,

--- a/CliWrap/Command.cs
+++ b/CliWrap/Command.cs
@@ -20,7 +20,7 @@ public partial class Command(
     PipeSource standardInputPipe,
     PipeTarget standardOutputPipe,
     PipeTarget standardErrorPipe,
-    bool waitForOutputProcessing
+    CommandExitCondition commandExitCondition
 ) : ICommandConfiguration
 {
     /// <summary>
@@ -37,7 +37,7 @@ public partial class Command(
             PipeSource.Null,
             PipeTarget.Null,
             PipeTarget.Null,
-            true
+            CommandExitCondition.PipesClosed
         ) { }
 
     /// <inheritdoc />
@@ -53,7 +53,7 @@ public partial class Command(
     public Credentials Credentials { get; } = credentials;
 
     /// <inheritdoc />
-    public bool WaitForOutputProcessing { get; } = waitForOutputProcessing;
+    public CommandExitCondition CommandExitCondition { get; } = commandExitCondition;
 
     /// <inheritdoc />
     public IReadOnlyDictionary<string, string?> EnvironmentVariables { get; } =
@@ -86,7 +86,7 @@ public partial class Command(
             StandardInputPipe,
             StandardOutputPipe,
             StandardErrorPipe,
-            WaitForOutputProcessing
+            CommandExitCondition
         );
 
     /// <summary>
@@ -108,7 +108,7 @@ public partial class Command(
             StandardInputPipe,
             StandardOutputPipe,
             StandardErrorPipe,
-            WaitForOutputProcessing
+            CommandExitCondition
         );
 
     /// <summary>
@@ -155,7 +155,7 @@ public partial class Command(
             StandardInputPipe,
             StandardOutputPipe,
             StandardErrorPipe,
-            WaitForOutputProcessing
+            CommandExitCondition
         );
 
     /// <summary>
@@ -173,7 +173,7 @@ public partial class Command(
             StandardInputPipe,
             StandardOutputPipe,
             StandardErrorPipe,
-            WaitForOutputProcessing
+            CommandExitCondition
         );
 
     /// <summary>
@@ -206,7 +206,7 @@ public partial class Command(
             StandardInputPipe,
             StandardOutputPipe,
             StandardErrorPipe,
-            WaitForOutputProcessing
+            CommandExitCondition
         );
 
     /// <summary>
@@ -237,14 +237,14 @@ public partial class Command(
             StandardInputPipe,
             StandardOutputPipe,
             StandardErrorPipe,
-            WaitForOutputProcessing
+            CommandExitCondition
         );
 
     /// <summary>
-    /// Creates a copy of this command, setting the waiting for output processing flag to the specified value.
+    /// Creates a copy of this command, setting the exit condition to the specified value.
     /// </summary>
     [Pure]
-    public Command WithWaitingForOutputProcessing(bool waitForOutputProcessing = true) =>
+    public Command WithExitCondition(CommandExitCondition commandExitCondition) =>
         new(
             TargetFilePath,
             Arguments,
@@ -255,7 +255,7 @@ public partial class Command(
             StandardInputPipe,
             StandardOutputPipe,
             StandardErrorPipe,
-            waitForOutputProcessing
+            commandExitCondition
         );
 
     /// <summary>
@@ -273,7 +273,7 @@ public partial class Command(
             source,
             StandardOutputPipe,
             StandardErrorPipe,
-            WaitForOutputProcessing
+            CommandExitCondition
         );
 
     /// <summary>
@@ -291,7 +291,7 @@ public partial class Command(
             StandardInputPipe,
             target,
             StandardErrorPipe,
-            WaitForOutputProcessing
+            CommandExitCondition
         );
 
     /// <summary>
@@ -309,7 +309,7 @@ public partial class Command(
             StandardInputPipe,
             StandardOutputPipe,
             target,
-            WaitForOutputProcessing
+            CommandExitCondition
         );
 
     /// <inheritdoc />

--- a/CliWrap/Command.cs
+++ b/CliWrap/Command.cs
@@ -19,7 +19,8 @@ public partial class Command(
     CommandResultValidation validation,
     PipeSource standardInputPipe,
     PipeTarget standardOutputPipe,
-    PipeTarget standardErrorPipe
+    PipeTarget standardErrorPipe,
+    bool waitForOutputProcessing
 ) : ICommandConfiguration
 {
     /// <summary>
@@ -35,7 +36,8 @@ public partial class Command(
             CommandResultValidation.ZeroExitCode,
             PipeSource.Null,
             PipeTarget.Null,
-            PipeTarget.Null
+            PipeTarget.Null,
+            true
         ) { }
 
     /// <inheritdoc />
@@ -49,6 +51,9 @@ public partial class Command(
 
     /// <inheritdoc />
     public Credentials Credentials { get; } = credentials;
+
+    /// <inheritdoc />
+    public bool WaitForOutputProcessing { get; } = waitForOutputProcessing;
 
     /// <inheritdoc />
     public IReadOnlyDictionary<string, string?> EnvironmentVariables { get; } =
@@ -80,7 +85,8 @@ public partial class Command(
             Validation,
             StandardInputPipe,
             StandardOutputPipe,
-            StandardErrorPipe
+            StandardErrorPipe,
+            WaitForOutputProcessing
         );
 
     /// <summary>
@@ -101,7 +107,8 @@ public partial class Command(
             Validation,
             StandardInputPipe,
             StandardOutputPipe,
-            StandardErrorPipe
+            StandardErrorPipe,
+            WaitForOutputProcessing
         );
 
     /// <summary>
@@ -147,7 +154,8 @@ public partial class Command(
             Validation,
             StandardInputPipe,
             StandardOutputPipe,
-            StandardErrorPipe
+            StandardErrorPipe,
+            WaitForOutputProcessing
         );
 
     /// <summary>
@@ -164,7 +172,8 @@ public partial class Command(
             Validation,
             StandardInputPipe,
             StandardOutputPipe,
-            StandardErrorPipe
+            StandardErrorPipe,
+            WaitForOutputProcessing
         );
 
     /// <summary>
@@ -196,7 +205,8 @@ public partial class Command(
             Validation,
             StandardInputPipe,
             StandardOutputPipe,
-            StandardErrorPipe
+            StandardErrorPipe,
+            WaitForOutputProcessing
         );
 
     /// <summary>
@@ -226,7 +236,26 @@ public partial class Command(
             validation,
             StandardInputPipe,
             StandardOutputPipe,
-            StandardErrorPipe
+            StandardErrorPipe,
+            WaitForOutputProcessing
+        );
+
+    /// <summary>
+    /// Creates a copy of this command, setting the waiting for output processing flag to the specified value.
+    /// </summary>
+    [Pure]
+    public Command WithWaitingForOutputProcessing(bool waitForOutputProcessing = true) =>
+        new(
+            TargetFilePath,
+            Arguments,
+            WorkingDirPath,
+            Credentials,
+            EnvironmentVariables,
+            Validation,
+            StandardInputPipe,
+            StandardOutputPipe,
+            StandardErrorPipe,
+            waitForOutputProcessing
         );
 
     /// <summary>
@@ -243,7 +272,8 @@ public partial class Command(
             Validation,
             source,
             StandardOutputPipe,
-            StandardErrorPipe
+            StandardErrorPipe,
+            WaitForOutputProcessing
         );
 
     /// <summary>
@@ -260,7 +290,8 @@ public partial class Command(
             Validation,
             StandardInputPipe,
             target,
-            StandardErrorPipe
+            StandardErrorPipe,
+            WaitForOutputProcessing
         );
 
     /// <summary>
@@ -277,7 +308,8 @@ public partial class Command(
             Validation,
             StandardInputPipe,
             StandardOutputPipe,
-            target
+            target,
+            WaitForOutputProcessing
         );
 
     /// <inheritdoc />

--- a/CliWrap/CommandExitCondition.cs
+++ b/CliWrap/CommandExitCondition.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace CliWrap;
+
+/// <summary>
+/// Strategy used for veryfing the end of command exectuion.
+/// </summary>
+[Flags]
+public enum CommandExitCondition
+{
+    /// <summary>
+    /// Command is finished when process is finished and all pipes are closed.
+    /// </summary>
+    PipesClosed = 0,
+
+    /// <summary>
+    /// Command is finished when the main process exits,
+    /// even if they are child processes still running, which are reusing the same output/error streams.
+    /// </summary>
+    ProcessExited = 1
+}

--- a/CliWrap/CommandExitCondition.cs
+++ b/CliWrap/CommandExitCondition.cs
@@ -1,21 +1,18 @@
-﻿using System;
-
-namespace CliWrap;
+﻿namespace CliWrap;
 
 /// <summary>
-/// Strategy used for veryfing the end of command exectuion.
+/// Strategy used for identifying the end of command exectuion.
 /// </summary>
-[Flags]
 public enum CommandExitCondition
 {
     /// <summary>
-    /// Command is finished when process is finished and all pipes are closed.
+    /// Command execution is considered finished when the process exits and all standard input and output streams are closed.
     /// </summary>
     PipesClosed = 0,
 
     /// <summary>
-    /// Command is finished when the main process exits,
-    /// even if they are child processes still running, which are reusing the same output/error streams.
+    /// Command execution is considered finished when the process exits, even if the process's standard input and output streams are still open,
+    /// for example after being inherited by a grandchild process.
     /// </summary>
     ProcessExited = 1
 }

--- a/CliWrap/ICommandConfiguration.cs
+++ b/CliWrap/ICommandConfiguration.cs
@@ -28,6 +28,11 @@ public interface ICommandConfiguration
     Credentials Credentials { get; }
 
     /// <summary>
+    /// Strategy used for veryfing the end of command exectuion.
+    /// </summary>
+    public CommandExitCondition CommandExitCondition { get; }
+
+    /// <summary>
     /// Environment variables set for the underlying process.
     /// </summary>
     IReadOnlyDictionary<string, string?> EnvironmentVariables { get; }

--- a/CliWrap/Utils/ProcessEx.cs
+++ b/CliWrap/Utils/ProcessEx.cs
@@ -146,5 +146,17 @@ internal class ProcessEx(ProcessStartInfo startInfo) : IDisposable
             await _exitTcs.Task.ConfigureAwait(false);
     }
 
+    public async Task WaitUntilExitNoOutputProcessingAsync(
+        CancellationToken cancellationToken = default
+    )
+    {
+        await using (
+            cancellationToken
+                .Register(() => _exitTcs.TrySetCanceled(cancellationToken))
+                .ToAsyncDisposable()
+        )
+            await Task.Run(() => _nativeProcess.WaitForExit(int.MaxValue), cancellationToken);
+    }
+
     public void Dispose() => _nativeProcess.Dispose();
 }

--- a/CliWrap/Utils/ProcessEx.cs
+++ b/CliWrap/Utils/ProcessEx.cs
@@ -146,17 +146,5 @@ internal class ProcessEx(ProcessStartInfo startInfo) : IDisposable
             await _exitTcs.Task.ConfigureAwait(false);
     }
 
-    public async Task WaitUntilExitNoOutputProcessingAsync(
-        CancellationToken cancellationToken = default
-    )
-    {
-        await using (
-            cancellationToken
-                .Register(() => _exitTcs.TrySetCanceled(cancellationToken))
-                .ToAsyncDisposable()
-        )
-            await Task.Run(() => _nativeProcess.WaitForExit(int.MaxValue), cancellationToken);
-    }
-
     public void Dispose() => _nativeProcess.Dispose();
 }


### PR DESCRIPTION
Closes #241

Example usage:
```c#
var cmd = Cli.Wrap("powershell")
    .WithArguments("Start-Process -NoNewWindow -FilePath \"powershell\" -ArgumentList \"'sleep 1000'\"; exit 0")
    .WithWaitingForOutputProcessing(false)
    .WithStandardOutputPipe(PipeTarget.ToDelegate(line => Console.WriteLine($"STDOUT {line}")))
    .WithStandardErrorPipe(PipeTarget.ToDelegate(line => Console.WriteLine($"STDERR {line}")));


var result = await cmd.ExecuteAsync();
```
There is no breaking change. Current implementations will get `true` by default and will go with old, standard flow.