### PR TITLE
Piping task timeout

### DIFF
--- a/CliWrap.Tests.Dummy/Commands/RunProcessCommand.cs
+++ b/CliWrap.Tests.Dummy/Commands/RunProcessCommand.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using CliFx;
+using CliFx.Attributes;
+using CliFx.Infrastructure;
+
+namespace CliWrap.Tests.Dummy.Commands;
+
+[Command("run process")]
+public class RunProcessCommand : ICommand
+{
+    [CommandOption("path")]
+    public string FilePath { get; init; } = string.Empty;
+
+    [CommandOption("arguments")]
+    public string Arguments { get; init; } = string.Empty;
+
+    public ValueTask ExecuteAsync(IConsole console)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = FilePath,
+            Arguments = Arguments,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        var process = new Process();
+        process.StartInfo = startInfo;
+        process.Start();
+
+        console.Output.WriteLine(process.Id);
+
+        return default;
+    }
+}

--- a/CliWrap.Tests.Dummy/Commands/RunProcessCommand.cs
+++ b/CliWrap.Tests.Dummy/Commands/RunProcessCommand.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Threading.Tasks;
 using CliFx;
 using CliFx.Attributes;
@@ -29,8 +28,6 @@ public class RunProcessCommand : ICommand
         var process = new Process();
         process.StartInfo = startInfo;
         process.Start();
-
-        console.Output.WriteLine(process.Id);
 
         return default;
     }

--- a/CliWrap/Command.Execution.cs
+++ b/CliWrap/Command.Execution.cs
@@ -242,8 +242,11 @@ public partial class Command
             // If the pipe is still trying to transfer data, this will cause it to abort.
             await stdInCts.CancelAsync();
 
-            // Cancel piping after specified time.
-            pipeStdOutErrCts.CancelAfter(PipingTimeout);
+            if (PipingTimeout != null)
+            {
+                // Cancel piping after specified time.
+                pipeStdOutErrCts.CancelAfter(PipingTimeout.Value);
+            }
 
             // Wait until piping is done or cancelled and propagate exceptions
             await pipingTask.ConfigureAwait(false);

--- a/CliWrap/Command.cs
+++ b/CliWrap/Command.cs
@@ -20,7 +20,7 @@ public partial class Command(
     PipeSource standardInputPipe,
     PipeTarget standardOutputPipe,
     PipeTarget standardErrorPipe,
-    TimeSpan pipingTimeout
+    TimeSpan? pipingTimeout
 ) : ICommandConfiguration
 {
     /// <summary>
@@ -37,7 +37,7 @@ public partial class Command(
             PipeSource.Null,
             PipeTarget.Null,
             PipeTarget.Null,
-            TimeSpan.FromMilliseconds(int.MaxValue)
+            null
         ) { }
 
     /// <inheritdoc />
@@ -53,7 +53,7 @@ public partial class Command(
     public Credentials Credentials { get; } = credentials;
 
     /// <inheritdoc />
-    public TimeSpan PipingTimeout { get; } = pipingTimeout;
+    public TimeSpan? PipingTimeout { get; } = pipingTimeout;
 
     /// <inheritdoc />
     public IReadOnlyDictionary<string, string?> EnvironmentVariables { get; } =

--- a/CliWrap/Command.cs
+++ b/CliWrap/Command.cs
@@ -19,7 +19,8 @@ public partial class Command(
     CommandResultValidation validation,
     PipeSource standardInputPipe,
     PipeTarget standardOutputPipe,
-    PipeTarget standardErrorPipe
+    PipeTarget standardErrorPipe,
+    TimeSpan pipingTimeout
 ) : ICommandConfiguration
 {
     /// <summary>
@@ -35,7 +36,8 @@ public partial class Command(
             CommandResultValidation.ZeroExitCode,
             PipeSource.Null,
             PipeTarget.Null,
-            PipeTarget.Null
+            PipeTarget.Null,
+            TimeSpan.FromMilliseconds(int.MaxValue)
         ) { }
 
     /// <inheritdoc />
@@ -49,6 +51,9 @@ public partial class Command(
 
     /// <inheritdoc />
     public Credentials Credentials { get; } = credentials;
+
+    /// <inheritdoc />
+    public TimeSpan PipingTimeout { get; } = pipingTimeout;
 
     /// <inheritdoc />
     public IReadOnlyDictionary<string, string?> EnvironmentVariables { get; } =
@@ -80,7 +85,8 @@ public partial class Command(
             Validation,
             StandardInputPipe,
             StandardOutputPipe,
-            StandardErrorPipe
+            StandardErrorPipe,
+            PipingTimeout
         );
 
     /// <summary>
@@ -101,7 +107,8 @@ public partial class Command(
             Validation,
             StandardInputPipe,
             StandardOutputPipe,
-            StandardErrorPipe
+            StandardErrorPipe,
+            PipingTimeout
         );
 
     /// <summary>
@@ -147,7 +154,25 @@ public partial class Command(
             Validation,
             StandardInputPipe,
             StandardOutputPipe,
-            StandardErrorPipe
+            StandardErrorPipe,
+            PipingTimeout
+        );
+
+    /// <summary>
+    /// Creates a copy of this command, setting the piping timeout to the specified value.
+    /// </summary>
+    public Command WithPipingTimeout(TimeSpan pipingTimeout) =>
+        new(
+            TargetFilePath,
+            Arguments,
+            WorkingDirPath,
+            Credentials,
+            EnvironmentVariables,
+            Validation,
+            StandardInputPipe,
+            StandardOutputPipe,
+            StandardErrorPipe,
+            pipingTimeout
         );
 
     /// <summary>
@@ -164,7 +189,8 @@ public partial class Command(
             Validation,
             StandardInputPipe,
             StandardOutputPipe,
-            StandardErrorPipe
+            StandardErrorPipe,
+            PipingTimeout
         );
 
     /// <summary>
@@ -196,7 +222,8 @@ public partial class Command(
             Validation,
             StandardInputPipe,
             StandardOutputPipe,
-            StandardErrorPipe
+            StandardErrorPipe,
+            PipingTimeout
         );
 
     /// <summary>
@@ -226,7 +253,8 @@ public partial class Command(
             validation,
             StandardInputPipe,
             StandardOutputPipe,
-            StandardErrorPipe
+            StandardErrorPipe,
+            PipingTimeout
         );
 
     /// <summary>
@@ -243,7 +271,8 @@ public partial class Command(
             Validation,
             source,
             StandardOutputPipe,
-            StandardErrorPipe
+            StandardErrorPipe,
+            PipingTimeout
         );
 
     /// <summary>
@@ -260,7 +289,8 @@ public partial class Command(
             Validation,
             StandardInputPipe,
             target,
-            StandardErrorPipe
+            StandardErrorPipe,
+            PipingTimeout
         );
 
     /// <summary>
@@ -277,7 +307,8 @@ public partial class Command(
             Validation,
             StandardInputPipe,
             StandardOutputPipe,
-            target
+            target,
+            PipingTimeout
         );
 
     /// <inheritdoc />

--- a/CliWrap/Exceptions/PipesCancelledException.cs
+++ b/CliWrap/Exceptions/PipesCancelledException.cs
@@ -10,9 +10,8 @@ public class PipesCancelledException(
     int exitCode,
     DateTimeOffset startTime,
     DateTimeOffset exitTime,
-    string message,
-    CancellationToken token
-) : OperationCanceledException(message, token)
+    string message
+) : OperationCanceledException(message)
 {
     /// <summary>
     /// Exit code returned by the process.

--- a/CliWrap/Exceptions/PipesCancelledException.cs
+++ b/CliWrap/Exceptions/PipesCancelledException.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Threading;
+
+namespace CliWrap.Exceptions;
+
+/// <summary>
+/// The exception that is thrown when the pipes are cancelled.
+/// </summary>
+public class PipesCancelledException(
+    int exitCode,
+    DateTimeOffset startTime,
+    DateTimeOffset exitTime,
+    string message,
+    CancellationToken token
+) : OperationCanceledException(message, token)
+{
+    /// <summary>
+    /// Exit code returned by the process.
+    /// </summary>
+    public int ExitCode { get; } = exitCode;
+
+    /// <summary>
+    /// Time when the process started.
+    /// </summary>
+    public DateTimeOffset StartTime { get; } = startTime;
+
+    /// <summary>
+    /// Time when the process exited.
+    /// </summary>
+    public DateTimeOffset ExitTime { get; } = exitTime;
+}

--- a/CliWrap/ICommandConfiguration.cs
+++ b/CliWrap/ICommandConfiguration.cs
@@ -41,7 +41,7 @@ public interface ICommandConfiguration
     /// <summary>
     /// How long to wait for piping to be finished after the process exits.
     /// </summary>
-    public TimeSpan PipingTimeout { get; }
+    TimeSpan? PipingTimeout { get; }
 
     /// <summary>
     /// Pipe source for the standard input stream of the underlying process.

--- a/CliWrap/ICommandConfiguration.cs
+++ b/CliWrap/ICommandConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace CliWrap;
 
@@ -36,6 +37,11 @@ public interface ICommandConfiguration
     /// Strategy for validating the result of the execution.
     /// </summary>
     CommandResultValidation Validation { get; }
+
+    /// <summary>
+    /// How long to wait for piping to be finished after the process exits.
+    /// </summary>
+    public TimeSpan PipingTimeout { get; }
 
     /// <summary>
     /// Pipe source for the standard input stream of the underlying process.


### PR DESCRIPTION
Closes #241

It resolves the issue, by allowing to specify max timeout to wait for piping to be finished. By doing this way, we can customize how long to wait after the process is finished. The code throws exception, when waiting for piping exceeded timeout, which can be cached by client and it can be properly handled.

Timeout also gives flexibility for the client to give enough time to handle the output, so that it's not lost for the cases when child process is started, but it's important to read all output of the main process.

It's also a lot easier to create nice unit test for the behavior. Unfortunately, it .NET Framework behaves differently in the same case, so I had to exclude it in unit test. In .NET Framework, when main process is exited but child process is still running, the `Exited` event is not fired for some reason.

Example from unit test:
```
[Fact(Timeout = 10000)]
public async Task I_can_execute_a_command_and_cancel_piping_when_command_is_finished_but_child_process_remains_running()
{
    // Arrange
    var cmd = Cli.Wrap(Dummy.Program.FilePath)
        .WithArguments(
            [
                "run",
                "process",
                "--path",
                Dummy.Program.FilePath,
                "--arguments",
                "sleep 00:00:15"
            ]
        )
        .WithStandardOutputPipe(PipeTarget.ToDelegate(_ => { }))
        .WithStandardErrorPipe(PipeTarget.ToDelegate(_ => { }))
        .WithPipingTimeout(TimeSpan.FromSeconds(1));

    // Act
    var executeAsync = async () => await cmd.ExecuteAsync();

    // Assert
    var ex = await Assert.ThrowsAnyAsync<PipesCancelledException>(
        async () => await executeAsync()
    );

    ex.ExitCode.Should().Be(0);
}
```

Without ` .WithPipingTimeout(TimeSpan.FromSeconds(1))` this test gets timeout after 10 seconds.
