### PR TITLE
Expose `ArgumentsBuilder.Escape(...)`

### DIFF
--- a/CliWrap/Builders/ArgumentsBuilder.cs
+++ b/CliWrap/Builders/ArgumentsBuilder.cs
@@ -142,7 +142,16 @@ public partial class ArgumentsBuilder
 
 public partial class ArgumentsBuilder
 {
-    private static string Escape(string argument)
+    /// <summary>
+    /// Escapes special characters (spaces, slashes, and quotes) in the specified string, ensuring that the output
+    /// is correctly interpreted as a single argument when passed to a command-line application.
+    /// </summary>
+    /// <remarks>
+    /// In most cases, you should not need to use this method, as <see cref="ArgumentsBuilder" /> already escapes
+    /// arguments automatically. This method is provided for advanced scenarios where you need to escape arguments
+    /// manually.
+    /// </remarks>
+    public static string Escape(string argument)
     {
         // Implementation reference:
         // https://github.com/dotnet/runtime/blob/9a50493f9f1125fda5e2212b9d6718bc7cdbc5c0/src/libraries/System.Private.CoreLib/src/System/PasteArguments.cs#L10-L79

--- a/Readme.md
+++ b/Readme.md
@@ -219,6 +219,10 @@ var cmd = Cli.Wrap("git")
 > This method expects all arguments to be correctly escaped and formatted ahead of time — which can be cumbersome to do yourself.
 > Formatting errors may result in unexpected bugs and security vulnerabilities.
 
+> **Note**:
+> There are some [obscure scenarios](https://github.com/Tyrrrz/CliWrap/issues/263), where you may need to assemble the command-line arguments yourself.
+> In such cases, you can use the `ArgumentsBuilder.Escape(...)` method to escape individual arguments manually.
+
 #### `WithWorkingDirectory(...)`
 
 Sets the working directory of the child process.


### PR DESCRIPTION
Closes #263
