### PR TITLE
Add an overload of `PipeSource.FromCommand(...)` that accepts a transform function

### DIFF
--- a/CliWrap/PipeSource.cs
+++ b/CliWrap/PipeSource.cs
@@ -136,18 +136,17 @@ public partial class PipeSource
         Command command,
         Func<Stream, Stream, CancellationToken, Task> copyStreamAsync
     ) =>
+        // cmdA | <transform> | cmdB
         Create(
-            // Destination -> outer command's standard input
+            // Destination -> cmdB's standard input
             async (destination, destinationCancellationToken) =>
                 await command
                     .WithStandardOutputPipe(
                         PipeTarget.Create(
-                            // Source -> inner command's standard output
+                            // Source -> cmdA's standard output
                             async (source, sourceCancellationToken) =>
-                            {
                                 await copyStreamAsync(source, destination, sourceCancellationToken)
-                                    .ConfigureAwait(false);
-                            }
+                                    .ConfigureAwait(false)
                         )
                     )
                     .ExecuteAsync(destinationCancellationToken)
@@ -161,8 +160,6 @@ public partial class PipeSource
         FromCommand(
             command,
             async (source, destination, cancellationToken) =>
-            {
-                await source.CopyToAsync(destination, cancellationToken).ConfigureAwait(false);
-            }
+                await source.CopyToAsync(destination, cancellationToken).ConfigureAwait(false)
         );
 }


### PR DESCRIPTION
This overload allows the caller to pipe the output of one command into the input of another, while applying a manual transform between the source and the destination data.

Currently, the transform is a rudimentary `Func<Stream, Stream, CancellationToken, Task>` low-level function which works with streams directly (output of the first command and the input of the second command, respectively). In the future, we can build upon this foundation to provide higher level transforms, but right now I'm not sure if there's much demand for it.

Example usage:

```csharp
[Fact(Timeout = 15000)]
public async Task I_can_execute_a_command_and_pipe_the_stdin_from_another_command_with_a_transform()
{
    // Arrange
    var cmdInput = Cli.Wrap(Dummy.Program.FilePath)
        .WithArguments(["generate binary", "--length", "100000"]);

    var cmd = Cli.Wrap(Dummy.Program.FilePath)
        .WithArguments("length stdin")
        .WithStandardInputPipe(
            PipeSource.FromCommand(
                cmdInput,
                // Take only the first 5000 bytes
                async (source, destination, cancellationToken) =>
                {
                    using var buffer = MemoryPool<byte>.Shared.Rent(5000);

                    await source.ReadAtLeastAsync(
                        buffer.Memory,
                        5000,
                        false,
                        cancellationToken
                    );

                    await destination.WriteAsync(buffer.Memory[..5000], cancellationToken);
                }
            )
        );

    // Act
    var result = await cmd.ExecuteBufferedAsync();

    // Assert
    result.StandardOutput.Trim().Should().Be("5000");
}
```

The above example demonstrates how the command `generate binary` is piped into `length stdin` and the transform is responsible for cutting off all but the first 5000 bytes. Of course, you can perform much more complicated transformations here as well, and the fact that the operations are performed against streams (rather than materialized data) makes these operations memory-efficient.

Closes #206