### PR TITLE
Add support for resource policies

### DIFF
--- a/CliWrap.Tests/ConfigurationSpecs.cs
+++ b/CliWrap.Tests/ConfigurationSpecs.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
+using CliWrap.Builders;
 using FluentAssertions;
 using Xunit;
 
@@ -17,6 +19,7 @@ public class ConfigurationSpecs
         cmd.TargetFilePath.Should().Be("foo");
         cmd.Arguments.Should().BeEmpty();
         cmd.WorkingDirPath.Should().Be(Directory.GetCurrentDirectory());
+        cmd.ResourcePolicy.Should().Be(ResourcePolicy.Default);
         cmd.Credentials.Should().BeEquivalentTo(Credentials.Default);
         cmd.EnvironmentVariables.Should().BeEmpty();
         cmd.Validation.Should().Be(CommandResultValidation.ZeroExitCode);
@@ -107,6 +110,52 @@ public class ConfigurationSpecs
         original.Should().BeEquivalentTo(modified, o => o.Excluding(c => c.WorkingDirPath));
         original.WorkingDirPath.Should().NotBe(modified.WorkingDirPath);
         modified.WorkingDirPath.Should().Be("new");
+    }
+
+    [Fact]
+    public void I_can_configure_the_resource_policy()
+    {
+        // Arrange
+        var original = Cli.Wrap("foo").WithResourcePolicy(ResourcePolicy.Default);
+
+        // Act
+        var modified = original.WithResourcePolicy(
+            new ResourcePolicyBuilder()
+                .SetPriority(ProcessPriorityClass.High)
+                .SetAffinity(0x1)
+                .SetMinWorkingSet(1024)
+                .SetMaxWorkingSet(2048)
+                .Build()
+        );
+
+        // Assert
+        original.Should().BeEquivalentTo(modified, o => o.Excluding(c => c.ResourcePolicy));
+        original.ResourcePolicy.Should().NotBe(modified.ResourcePolicy);
+        modified
+            .ResourcePolicy.Should()
+            .BeEquivalentTo(new ResourcePolicy(ProcessPriorityClass.High, 0x1, 1024, 2048));
+    }
+
+    [Fact]
+    public void I_can_configure_the_resource_policy_using_a_builder()
+    {
+        // Arrange
+        var original = Cli.Wrap("foo").WithResourcePolicy(ResourcePolicy.Default);
+
+        // Act
+        var modified = original.WithResourcePolicy(b =>
+            b.SetPriority(ProcessPriorityClass.High)
+                .SetAffinity(0x1)
+                .SetMinWorkingSet(1024)
+                .SetMaxWorkingSet(2048)
+        );
+
+        // Assert
+        original.Should().BeEquivalentTo(modified, o => o.Excluding(c => c.ResourcePolicy));
+        original.ResourcePolicy.Should().NotBe(modified.ResourcePolicy);
+        modified
+            .ResourcePolicy.Should()
+            .BeEquivalentTo(new ResourcePolicy(ProcessPriorityClass.High, 0x1, 1024, 2048));
     }
 
     [Fact]

--- a/CliWrap.Tests/ConfigurationSpecs.cs
+++ b/CliWrap.Tests/ConfigurationSpecs.cs
@@ -120,12 +120,7 @@ public class ConfigurationSpecs
 
         // Act
         var modified = original.WithResourcePolicy(
-            new ResourcePolicyBuilder()
-                .SetPriority(ProcessPriorityClass.High)
-                .SetAffinity(0x1)
-                .SetMinWorkingSet(1024)
-                .SetMaxWorkingSet(2048)
-                .Build()
+            new ResourcePolicy(ProcessPriorityClass.High, 0x1, 1024, 2048)
         );
 
         // Assert

--- a/CliWrap.Tests/CredentialsSpecs.cs
+++ b/CliWrap.Tests/CredentialsSpecs.cs
@@ -58,7 +58,7 @@ public class CredentialsSpecs
     {
         Skip.If(
             RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
-            "Starting a process as another user is only supported on Windows."
+            "Starting a process as another user is fully supported on Windows."
         );
 
         // Arrange

--- a/CliWrap.Tests/ResourcePolicySpecs.cs
+++ b/CliWrap.Tests/ResourcePolicySpecs.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -9,7 +10,7 @@ namespace CliWrap.Tests;
 public class ResourcePolicySpecs
 {
     [SkippableFact(Timeout = 15000)]
-    public async Task I_can_execute_a_command_with_custom_process_priority()
+    public async Task I_can_execute_a_command_with_a_custom_process_priority()
     {
         Skip.IfNot(
             RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
@@ -28,7 +29,7 @@ public class ResourcePolicySpecs
     }
 
     [SkippableFact(Timeout = 15000)]
-    public async Task I_can_execute_a_command_with_custom_affinity_mask()
+    public async Task I_can_execute_a_command_with_a_custom_affinity_mask()
     {
         Skip.IfNot(
             RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
@@ -47,7 +48,7 @@ public class ResourcePolicySpecs
     }
 
     [SkippableFact(Timeout = 15000)]
-    public async Task I_can_execute_a_command_with_custom_working_set_limits()
+    public async Task I_can_execute_a_command_with_a_custom_working_set_limit()
     {
         Skip.IfNot(
             RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
@@ -66,5 +67,21 @@ public class ResourcePolicySpecs
 
         // Assert
         result.ExitCode.Should().Be(0);
+    }
+
+    [SkippableFact(Timeout = 15000)]
+    public async Task I_can_execute_a_command_with_a_custom_resource_policy_and_get_an_error_if_the_operating_system_does_not_support_it()
+    {
+        Skip.If(
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+            "Starting a process with a custom resource policy is fully supported on Windows."
+        );
+
+        // Arrange
+        var cmd = Cli.Wrap(Dummy.Program.FilePath)
+            .WithResourcePolicy(p => p.SetPriority(ProcessPriorityClass.High).SetAffinity(0b1010));
+
+        // Act & assert
+        await Assert.ThrowsAsync<NotSupportedException>(() => cmd.ExecuteAsync());
     }
 }

--- a/CliWrap.Tests/ResourcePolicySpecs.cs
+++ b/CliWrap.Tests/ResourcePolicySpecs.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
@@ -10,6 +11,11 @@ public class ResourcePolicySpecs
     [SkippableFact(Timeout = 15000)]
     public async Task I_can_execute_a_command_with_custom_process_priority()
     {
+        Skip.IfNot(
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+            "Starting a process with custom priority is only supported on Windows."
+        );
+
         // Arrange
         var cmd = Cli.Wrap(Dummy.Program.FilePath)
             .WithResourcePolicy(p => p.SetPriority(ProcessPriorityClass.High));
@@ -24,6 +30,11 @@ public class ResourcePolicySpecs
     [SkippableFact(Timeout = 15000)]
     public async Task I_can_execute_a_command_with_custom_affinity_mask()
     {
+        Skip.IfNot(
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux),
+            "Starting a process with custom affinity is only supported on Windows and Linux."
+        );
+
         // Arrange
         var cmd = Cli.Wrap(Dummy.Program.FilePath).WithResourcePolicy(p => p.SetAffinity(0b1010)); // Cores 1 and 3
 
@@ -37,6 +48,11 @@ public class ResourcePolicySpecs
     [SkippableFact(Timeout = 15000)]
     public async Task I_can_execute_a_command_with_custom_working_set_limits()
     {
+        Skip.IfNot(
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+            "Starting a process with custom priority is only supported on Windows."
+        );
+
         // Arrange
         var cmd = Cli.Wrap(Dummy.Program.FilePath)
             .WithResourcePolicy(p =>

--- a/CliWrap.Tests/ResourcePolicySpecs.cs
+++ b/CliWrap.Tests/ResourcePolicySpecs.cs
@@ -1,0 +1,53 @@
+﻿using System.Diagnostics;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace CliWrap.Tests;
+
+public class ResourcePolicySpecs
+{
+    [SkippableFact(Timeout = 15000)]
+    public async Task I_can_execute_a_command_with_custom_process_priority()
+    {
+        // Arrange
+        var cmd = Cli.Wrap(Dummy.Program.FilePath)
+            .WithResourcePolicy(p => p.SetPriority(ProcessPriorityClass.High));
+
+        // Act
+        var result = await cmd.ExecuteAsync();
+
+        // Assert
+        result.ExitCode.Should().Be(0);
+    }
+
+    [SkippableFact(Timeout = 15000)]
+    public async Task I_can_execute_a_command_with_custom_affinity_mask()
+    {
+        // Arrange
+        var cmd = Cli.Wrap(Dummy.Program.FilePath).WithResourcePolicy(p => p.SetAffinity(0b1010)); // Cores 1 and 3
+
+        // Act
+        var result = await cmd.ExecuteAsync();
+
+        // Assert
+        result.ExitCode.Should().Be(0);
+    }
+
+    [SkippableFact(Timeout = 15000)]
+    public async Task I_can_execute_a_command_with_custom_working_set_limits()
+    {
+        // Arrange
+        var cmd = Cli.Wrap(Dummy.Program.FilePath)
+            .WithResourcePolicy(p =>
+                p.SetMinWorkingSet(1024 * 1024) // 1 MB
+                    .SetMaxWorkingSet(1024 * 1024 * 10) // 10 MB
+            );
+
+        // Act
+        var result = await cmd.ExecuteAsync();
+
+        // Assert
+        result.ExitCode.Should().Be(0);
+    }
+}

--- a/CliWrap.Tests/ResourcePolicySpecs.cs
+++ b/CliWrap.Tests/ResourcePolicySpecs.cs
@@ -72,7 +72,7 @@ public class ResourcePolicySpecs
     }
 
     [SkippableFact(Timeout = 15000)]
-    public async Task I_can_execute_a_command_with_a_custom_resource_policy_and_get_an_error_if_the_operating_system_does_not_support_it()
+    public async Task I_can_try_to_execute_a_command_with_a_custom_resource_policy_and_get_an_error_if_the_operating_system_does_not_support_it()
     {
         Skip.If(
             RuntimeInformation.IsOSPlatform(OSPlatform.Windows),

--- a/CliWrap.Tests/ResourcePolicySpecs.cs
+++ b/CliWrap.Tests/ResourcePolicySpecs.cs
@@ -31,7 +31,8 @@ public class ResourcePolicySpecs
     public async Task I_can_execute_a_command_with_custom_affinity_mask()
     {
         Skip.IfNot(
-            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux),
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                || RuntimeInformation.IsOSPlatform(OSPlatform.Linux),
             "Starting a process with custom affinity is only supported on Windows and Linux."
         );
 

--- a/CliWrap.Tests/ResourcePolicySpecs.cs
+++ b/CliWrap.Tests/ResourcePolicySpecs.cs
@@ -12,6 +12,8 @@ public class ResourcePolicySpecs
     [SkippableFact(Timeout = 15000)]
     public async Task I_can_execute_a_command_with_a_custom_process_priority()
     {
+        // Process priority is supported on other platforms, but setting it requires elevated permissions,
+        // which we cannot guarantee in a CI environment. Therefore, we only test this on Windows.
         Skip.IfNot(
             RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
             "Starting a process with a custom priority is only supported on Windows."
@@ -79,7 +81,7 @@ public class ResourcePolicySpecs
 
         // Arrange
         var cmd = Cli.Wrap(Dummy.Program.FilePath)
-            .WithResourcePolicy(p => p.SetPriority(ProcessPriorityClass.High).SetAffinity(0b1010));
+            .WithResourcePolicy(p => p.SetMinWorkingSet(1024 * 1024));
 
         // Act & assert
         await Assert.ThrowsAsync<NotSupportedException>(() => cmd.ExecuteAsync());

--- a/CliWrap.Tests/ResourcePolicySpecs.cs
+++ b/CliWrap.Tests/ResourcePolicySpecs.cs
@@ -31,12 +31,12 @@ public class ResourcePolicySpecs
     }
 
     [SkippableFact(Timeout = 15000)]
-    public async Task I_can_execute_a_command_with_a_custom_affinity_mask()
+    public async Task I_can_execute_a_command_with_a_custom_core_affinity()
     {
         Skip.IfNot(
             RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                 || RuntimeInformation.IsOSPlatform(OSPlatform.Linux),
-            "Starting a process with a custom affinity mask is only supported on Windows and Linux."
+            "Starting a process with a custom core affinity is only supported on Windows and Linux."
         );
 
         // Arrange

--- a/CliWrap.Tests/ResourcePolicySpecs.cs
+++ b/CliWrap.Tests/ResourcePolicySpecs.cs
@@ -14,7 +14,7 @@ public class ResourcePolicySpecs
     {
         Skip.IfNot(
             RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
-            "Starting a process with custom priority is only supported on Windows."
+            "Starting a process with a custom priority is only supported on Windows."
         );
 
         // Arrange
@@ -34,7 +34,7 @@ public class ResourcePolicySpecs
         Skip.IfNot(
             RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                 || RuntimeInformation.IsOSPlatform(OSPlatform.Linux),
-            "Starting a process with custom affinity is only supported on Windows and Linux."
+            "Starting a process with a custom affinity mask is only supported on Windows and Linux."
         );
 
         // Arrange
@@ -52,7 +52,7 @@ public class ResourcePolicySpecs
     {
         Skip.IfNot(
             RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
-            "Starting a process with custom priority is only supported on Windows."
+            "Starting a process with a custom working set limit is only supported on Windows."
         );
 
         // Arrange

--- a/CliWrap/Builders/ResourcePolicyBuilder.cs
+++ b/CliWrap/Builders/ResourcePolicyBuilder.cs
@@ -22,8 +22,8 @@ public class ResourcePolicyBuilder
     }
 
     /// <summary>
-    /// Sets the processor affinity mask of the process.
-    /// For example, to set the affinity to cores 1 and 3, pass 0b1010.
+    /// Sets the processor core affinity mask of the process.
+    /// For example, to set the affinity to cores 1 and 3 out of 4, pass 0b1010.
     /// </summary>
     public ResourcePolicyBuilder SetAffinity(nint? affinity)
     {

--- a/CliWrap/Builders/ResourcePolicyBuilder.cs
+++ b/CliWrap/Builders/ResourcePolicyBuilder.cs
@@ -1,0 +1,56 @@
+﻿using System.Diagnostics;
+
+namespace CliWrap.Builders;
+
+/// <summary>
+/// Builder that helps configure resource policy.
+/// </summary>
+public class ResourcePolicyBuilder
+{
+    private ProcessPriorityClass _priority = ProcessPriorityClass.Normal;
+    private nint? _affinity;
+    private nint? _minWorkingSet;
+    private nint? _maxWorkingSet;
+
+    /// <summary>
+    /// Sets the priority class of the process.
+    /// </summary>
+    public ResourcePolicyBuilder SetPriority(ProcessPriorityClass priority)
+    {
+        _priority = priority;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the processor affinity mask of the process.
+    /// For example, to set the affinity to cores 1 and 3, pass 0b1010.
+    /// </summary>
+    public ResourcePolicyBuilder SetAffinity(nint? affinity)
+    {
+        _affinity = affinity;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the minimum working set size of the process.
+    /// </summary>
+    public ResourcePolicyBuilder SetMinWorkingSet(nint? minWorkingSet)
+    {
+        _minWorkingSet = minWorkingSet;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the maximum working set size of the process.
+    /// </summary>
+    public ResourcePolicyBuilder SetMaxWorkingSet(nint? maxWorkingSet)
+    {
+        _maxWorkingSet = maxWorkingSet;
+        return this;
+    }
+
+    /// <summary>
+    /// Builds the resulting resource policy.
+    /// </summary>
+    public ResourcePolicy Build() => new(_priority, _affinity, _minWorkingSet, _maxWorkingSet);
+}

--- a/CliWrap/Command.Execution.cs
+++ b/CliWrap/Command.Execution.cs
@@ -115,7 +115,7 @@ public partial class Command
         {
             throw new NotSupportedException(
                 "Cannot start a process using the provided credentials. "
-                    + "Setting custom domain, password, or loading user profile is only supported on Windows.",
+                    + "Setting custom domain, username, password, and/or loading the user profile is not supported on this platform.",
                 ex
             );
         }
@@ -313,12 +313,12 @@ public partial class Command
         // https://github.com/Tyrrrz/CliWrap/issues/139
         process.Start(p =>
         {
-            p.PriorityClass = ResourcePolicy.Priority;
-
             try
             {
                 // Disable CA1416 because we're handling an exception that is thrown by the property setters
 #pragma warning disable CA1416
+                p.PriorityClass = ResourcePolicy.Priority;
+
                 if (ResourcePolicy.Affinity is not null)
                     p.ProcessorAffinity = ResourcePolicy.Affinity.Value;
 
@@ -333,7 +333,7 @@ public partial class Command
             {
                 throw new PlatformNotSupportedException(
                     "Cannot set resource policy for the process. "
-                        + "Setting custom priority, affinity, or working set limits is only supported on Windows.",
+                        + "Setting custom priority, affinity, and/or working set limits is not supported on this platform.",
                     ex
                 );
             }

--- a/CliWrap/Command.Execution.cs
+++ b/CliWrap/Command.Execution.cs
@@ -329,9 +329,9 @@ public partial class Command
                     p.MaxWorkingSet = ResourcePolicy.MaxWorkingSet.Value;
 #pragma warning restore CA1416
             }
-            catch (PlatformNotSupportedException ex)
+            catch (NotSupportedException ex)
             {
-                throw new PlatformNotSupportedException(
+                throw new NotSupportedException(
                     "Cannot set resource policy for the process. "
                         + "Setting custom priority, affinity, and/or working set limits is not supported on this platform.",
                     ex

--- a/CliWrap/Command.cs
+++ b/CliWrap/Command.cs
@@ -14,6 +14,7 @@ public partial class Command(
     string targetFilePath,
     string arguments,
     string workingDirPath,
+    ResourcePolicy resourcePolicy,
     Credentials credentials,
     IReadOnlyDictionary<string, string?> environmentVariables,
     CommandResultValidation validation,
@@ -30,6 +31,7 @@ public partial class Command(
             targetFilePath,
             string.Empty,
             Directory.GetCurrentDirectory(),
+            ResourcePolicy.Default,
             Credentials.Default,
             new Dictionary<string, string?>(),
             CommandResultValidation.ZeroExitCode,
@@ -46,6 +48,9 @@ public partial class Command(
 
     /// <inheritdoc />
     public string WorkingDirPath { get; } = workingDirPath;
+
+    /// <inheritdoc />
+    public ResourcePolicy ResourcePolicy { get; } = resourcePolicy;
 
     /// <inheritdoc />
     public Credentials Credentials { get; } = credentials;
@@ -75,6 +80,7 @@ public partial class Command(
             targetFilePath,
             Arguments,
             WorkingDirPath,
+            ResourcePolicy,
             Credentials,
             EnvironmentVariables,
             Validation,
@@ -96,6 +102,7 @@ public partial class Command(
             TargetFilePath,
             arguments,
             WorkingDirPath,
+            ResourcePolicy,
             Credentials,
             EnvironmentVariables,
             Validation,
@@ -142,6 +149,7 @@ public partial class Command(
             TargetFilePath,
             Arguments,
             workingDirPath,
+            ResourcePolicy,
             Credentials,
             EnvironmentVariables,
             Validation,
@@ -149,6 +157,37 @@ public partial class Command(
             StandardOutputPipe,
             StandardErrorPipe
         );
+
+    /// <summary>
+    /// Creates a copy of this command, setting the resource policy to the specified value.
+    /// </summary>
+    [Pure]
+    public Command WithResourcePolicy(ResourcePolicy resourcePolicy) =>
+        new(
+            TargetFilePath,
+            Arguments,
+            WorkingDirPath,
+            resourcePolicy,
+            Credentials,
+            EnvironmentVariables,
+            Validation,
+            StandardInputPipe,
+            StandardOutputPipe,
+            StandardErrorPipe
+        );
+
+    /// <summary>
+    /// Creates a copy of this command, setting the resource policy to the value
+    /// configured by the specified delegate.
+    /// </summary>
+    [Pure]
+    public Command WithResourcePolicy(Action<ResourcePolicyBuilder> configure)
+    {
+        var builder = new ResourcePolicyBuilder();
+        configure(builder);
+
+        return WithResourcePolicy(builder.Build());
+    }
 
     /// <summary>
     /// Creates a copy of this command, setting the user credentials to the specified value.
@@ -159,6 +198,7 @@ public partial class Command(
             TargetFilePath,
             Arguments,
             WorkingDirPath,
+            ResourcePolicy,
             credentials,
             EnvironmentVariables,
             Validation,
@@ -191,6 +231,7 @@ public partial class Command(
             TargetFilePath,
             Arguments,
             WorkingDirPath,
+            ResourcePolicy,
             Credentials,
             environmentVariables,
             Validation,
@@ -221,6 +262,7 @@ public partial class Command(
             TargetFilePath,
             Arguments,
             WorkingDirPath,
+            ResourcePolicy,
             Credentials,
             EnvironmentVariables,
             validation,
@@ -238,6 +280,7 @@ public partial class Command(
             TargetFilePath,
             Arguments,
             WorkingDirPath,
+            ResourcePolicy,
             Credentials,
             EnvironmentVariables,
             Validation,
@@ -255,6 +298,7 @@ public partial class Command(
             TargetFilePath,
             Arguments,
             WorkingDirPath,
+            ResourcePolicy,
             Credentials,
             EnvironmentVariables,
             Validation,
@@ -272,6 +316,7 @@ public partial class Command(
             TargetFilePath,
             Arguments,
             WorkingDirPath,
+            ResourcePolicy,
             Credentials,
             EnvironmentVariables,
             Validation,

--- a/CliWrap/ICommandConfiguration.cs
+++ b/CliWrap/ICommandConfiguration.cs
@@ -23,6 +23,11 @@ public interface ICommandConfiguration
     string WorkingDirPath { get; }
 
     /// <summary>
+    /// Resource policy set for the underlying process.
+    /// </summary>
+    ResourcePolicy ResourcePolicy { get; }
+
+    /// <summary>
     /// User credentials set for the underlying process.
     /// </summary>
     Credentials Credentials { get; }

--- a/CliWrap/ResourcePolicy.cs
+++ b/CliWrap/ResourcePolicy.cs
@@ -1,0 +1,42 @@
+﻿using System.Diagnostics;
+
+namespace CliWrap;
+
+/// <summary>
+/// Resource policy assigned to a process.
+/// </summary>
+public partial class ResourcePolicy(
+    ProcessPriorityClass priority = ProcessPriorityClass.Normal,
+    nint? affinity = null,
+    nint? minWorkingSet = null,
+    nint? maxWorkingSet = null
+)
+{
+    /// <summary>
+    /// Priority class of the process.
+    /// </summary>
+    public ProcessPriorityClass Priority { get; } = priority;
+
+    /// <summary>
+    /// Processor affinity mask of the process.
+    /// </summary>
+    public nint? Affinity { get; } = affinity;
+
+    /// <summary>
+    /// Minimum working set size of the process.
+    /// </summary>
+    public nint? MinWorkingSet { get; } = minWorkingSet;
+
+    /// <summary>
+    /// Maximum working set size of the process.
+    /// </summary>
+    public nint? MaxWorkingSet { get; } = maxWorkingSet;
+}
+
+public partial class ResourcePolicy
+{
+    /// <summary>
+    /// Default resource policy.
+    /// </summary>
+    public static ResourcePolicy Default { get; } = new();
+}

--- a/CliWrap/ResourcePolicy.cs
+++ b/CliWrap/ResourcePolicy.cs
@@ -18,7 +18,7 @@ public partial class ResourcePolicy(
     public ProcessPriorityClass Priority { get; } = priority;
 
     /// <summary>
-    /// Processor affinity mask of the process.
+    /// Processor core affinity mask of the process.
     /// </summary>
     public nint? Affinity { get; } = affinity;
 

--- a/CliWrap/Utils/ProcessEx.cs
+++ b/CliWrap/Utils/ProcessEx.cs
@@ -42,7 +42,7 @@ internal class ProcessEx(ProcessStartInfo startInfo) : IDisposable
 
     public int ExitCode => _nativeProcess.ExitCode;
 
-    public void Start()
+    public void Start(Action<Process>? configureProcess = null)
     {
         // Hook up events
         _nativeProcess.EnableRaisingEvents = true;
@@ -64,6 +64,9 @@ internal class ProcessEx(ProcessStartInfo startInfo) : IDisposable
             }
 
             StartTime = DateTimeOffset.Now;
+
+            // Apply custom configurations
+            configureProcess?.Invoke(_nativeProcess);
         }
         catch (Win32Exception ex)
         {

--- a/Readme.md
+++ b/Readme.md
@@ -269,6 +269,38 @@ var cmd = Cli.Wrap("git")
 > Environment variables configured using `WithEnvironmentVariables(...)` are applied on top of those inherited from the parent process.
 > If you need to remove an inherited variable, set the corresponding value to `null`.
 
+#### `WithResourcePolicy(...)`
+
+Sets the system resource management policy for the child process.
+
+**Default**: default policy.
+
+**Examples**:
+
+- Set resource policy using a builder:
+
+```csharp
+var cmd = Cli.Wrap("git")
+    .WithResourcePolicy(policy => policy
+        .SetPriority(ProcessPriorityClass.High)
+        .SetAffinity(0b1010)
+        .SetMinWorkingSet(1024)
+        .SetMaxWorkingSet(4096)
+    );
+```
+
+- Set resource policy directly:
+
+```csharp
+var cmd = Cli.Wrap("git")
+    .WithResourcePolicy(new ResourcePolicy(
+        priority: ProcessPriorityClass.High,
+        affinity: 0b1010,
+        minWorkingSet: 1024,
+        maxWorkingSet: 4096
+    ));
+```
+
 #### `WithCredentials(...)`
 
 Sets domain, name and password of the user, under whom the child process should be started.

--- a/Readme.md
+++ b/Readme.md
@@ -301,6 +301,9 @@ var cmd = Cli.Wrap("git")
     ));
 ```
 
+> **Warning**:
+> Resource policy options have varying support across different platforms.
+
 #### `WithCredentials(...)`
 
 Sets domain, name and password of the user, under whom the child process should be started.


### PR DESCRIPTION
This PR adds a new configuration method called `WithResourcePolicy(...)`, along with a builder that helps the user configure process's priority, core affinity, and working set.

Closes #266