### PR TITLE
Allow Command to be subclassed by changing CreateStartInfo() private to protected virtual

### DIFF
--- a/CliWrap/Command.Execution.cs
+++ b/CliWrap/Command.Execution.cs
@@ -77,7 +77,7 @@ public partial class Command
 	/// <summary>
 	/// Creates and configures a new <see cref="ProcessStartInfo" /> instance for executing the command.
 	/// </summary>
-    protected ProcessStartInfo CreateStartInfo()
+    protected virtual ProcessStartInfo CreateStartInfo()
     {
         var startInfo = new ProcessStartInfo
         {

--- a/CliWrap/Command.Execution.cs
+++ b/CliWrap/Command.Execution.cs
@@ -74,9 +74,9 @@ public partial class Command
             ).FirstOrDefault(File.Exists) ?? TargetFilePath;
     }
 
-	/// <summary>
-	/// Creates and configures a new <see cref="ProcessStartInfo" /> instance for executing the command.
-	/// </summary>
+    /// <summary>
+    /// Creates and configures a new <see cref="ProcessStartInfo" /> instance for executing the command.
+    /// </summary>
     protected virtual ProcessStartInfo CreateStartInfo()
     {
         var startInfo = new ProcessStartInfo

--- a/CliWrap/Command.Execution.cs
+++ b/CliWrap/Command.Execution.cs
@@ -74,7 +74,10 @@ public partial class Command
             ).FirstOrDefault(File.Exists) ?? TargetFilePath;
     }
 
-    private ProcessStartInfo CreateStartInfo()
+	/// <summary>
+	/// Creates and configures a new <see cref="ProcessStartInfo" /> instance for executing the command.
+	/// </summary>
+    protected ProcessStartInfo CreateStartInfo()
     {
         var startInfo = new ProcessStartInfo
         {

--- a/CliWrap/Utils/ProcessEx.cs
+++ b/CliWrap/Utils/ProcessEx.cs
@@ -26,11 +26,11 @@ internal class ProcessEx(ProcessStartInfo startInfo) : IDisposable
     // We are purposely using Stream instead of StreamWriter/StreamReader to push the concerns of
     // writing and reading to PipeSource/PipeTarget at the higher level.
 
-    public Stream StandardInput => _nativeProcess.StandardInput.BaseStream;
+    public Stream StandardInput => _nativeProcess.StartInfo.RedirectStandardInput ? _nativeProcess.StandardInput.BaseStream : Stream.Null;
 
-    public Stream StandardOutput => _nativeProcess.StandardOutput.BaseStream;
+    public Stream StandardOutput => _nativeProcess.StartInfo.RedirectStandardOutput ? _nativeProcess.StandardOutput.BaseStream : Stream.Null;
 
-    public Stream StandardError => _nativeProcess.StandardError.BaseStream;
+    public Stream StandardError => _nativeProcess.StartInfo.RedirectStandardError ? _nativeProcess.StandardError.BaseStream : Stream.Null;
 
     // We have to keep track of StartTime ourselves because it becomes inaccessible after the process exits
     // https://github.com/Tyrrrz/CliWrap/issues/93


### PR DESCRIPTION
Also fixes `StandardInput`, `StandardOutput`, and `StandardError` properties on `ProcessEx` to return `Stream.Null` when not redirected.

Closes #79
