### PR TITLE
Allow Command to be subclassed by application code

### DIFF
--- a/CliWrap.Tests/ConfigurationSpecs.cs
+++ b/CliWrap.Tests/ConfigurationSpecs.cs
@@ -38,8 +38,7 @@ public class ConfigurationSpecs
         var modified = original.WithTargetFile("bar");
 
         // Assert
-        original.Should().BeEquivalentTo(modified, o => o.Excluding(c => c.TargetFilePath));
-        original.TargetFilePath.Should().NotBe(modified.TargetFilePath);
+        modified.Should().BeSameAs(original);
         modified.TargetFilePath.Should().Be("bar");
     }
 
@@ -53,8 +52,7 @@ public class ConfigurationSpecs
         var modified = original.WithArguments("qqq ppp");
 
         // Assert
-        original.Should().BeEquivalentTo(modified, o => o.Excluding(c => c.Arguments));
-        original.Arguments.Should().NotBe(modified.Arguments);
+        modified.Should().BeSameAs(original);
         modified.Arguments.Should().Be("qqq ppp");
     }
 
@@ -68,8 +66,7 @@ public class ConfigurationSpecs
         var modified = original.WithArguments(["-a", "foo bar"]);
 
         // Assert
-        original.Should().BeEquivalentTo(modified, o => o.Excluding(c => c.Arguments));
-        original.Arguments.Should().NotBe(modified.Arguments);
+        modified.Should().BeSameAs(original);
         modified.Arguments.Should().Be("-a \"foo bar\"");
     }
 
@@ -90,8 +87,7 @@ public class ConfigurationSpecs
         );
 
         // Assert
-        original.Should().BeEquivalentTo(modified, o => o.Excluding(c => c.Arguments));
-        original.Arguments.Should().NotBe(modified.Arguments);
+        modified.Should().BeSameAs(original);
         modified
             .Arguments.Should()
             .Be("-a \"foo bar\" \"\\\"foo\\\\bar\\\"\" 3.14 foo bar -5 89.13");
@@ -107,8 +103,7 @@ public class ConfigurationSpecs
         var modified = original.WithWorkingDirectory("new");
 
         // Assert
-        original.Should().BeEquivalentTo(modified, o => o.Excluding(c => c.WorkingDirPath));
-        original.WorkingDirPath.Should().NotBe(modified.WorkingDirPath);
+        modified.Should().BeSameAs(original);
         modified.WorkingDirPath.Should().Be("new");
     }
 
@@ -124,8 +119,7 @@ public class ConfigurationSpecs
         );
 
         // Assert
-        original.Should().BeEquivalentTo(modified, o => o.Excluding(c => c.ResourcePolicy));
-        original.ResourcePolicy.Should().NotBe(modified.ResourcePolicy);
+        modified.Should().BeSameAs(original);
         modified
             .ResourcePolicy.Should()
             .BeEquivalentTo(new ResourcePolicy(ProcessPriorityClass.High, 0x1, 1024, 2048));
@@ -146,8 +140,7 @@ public class ConfigurationSpecs
         );
 
         // Assert
-        original.Should().BeEquivalentTo(modified, o => o.Excluding(c => c.ResourcePolicy));
-        original.ResourcePolicy.Should().NotBe(modified.ResourcePolicy);
+        modified.Should().BeSameAs(original);
         modified
             .ResourcePolicy.Should()
             .BeEquivalentTo(new ResourcePolicy(ProcessPriorityClass.High, 0x1, 1024, 2048));
@@ -165,8 +158,7 @@ public class ConfigurationSpecs
         );
 
         // Assert
-        original.Should().BeEquivalentTo(modified, o => o.Excluding(c => c.Credentials));
-        original.Credentials.Should().NotBe(modified.Credentials);
+        modified.Should().BeSameAs(original);
         modified
             .Credentials.Should()
             .BeEquivalentTo(new Credentials("domain", "username", "password", true));
@@ -184,8 +176,7 @@ public class ConfigurationSpecs
         );
 
         // Assert
-        original.Should().BeEquivalentTo(modified, o => o.Excluding(c => c.Credentials));
-        original.Credentials.Should().NotBe(modified.Credentials);
+        modified.Should().BeSameAs(original);
         modified
             .Credentials.Should()
             .BeEquivalentTo(new Credentials("domain", "username", "password", true));
@@ -203,8 +194,7 @@ public class ConfigurationSpecs
         );
 
         // Assert
-        original.Should().BeEquivalentTo(modified, o => o.Excluding(c => c.EnvironmentVariables));
-        original.EnvironmentVariables.Should().NotBeEquivalentTo(modified.EnvironmentVariables);
+        modified.Should().BeSameAs(original);
         modified
             .EnvironmentVariables.Should()
             .BeEquivalentTo(
@@ -226,8 +216,7 @@ public class ConfigurationSpecs
         );
 
         // Assert
-        original.Should().BeEquivalentTo(modified, o => o.Excluding(c => c.EnvironmentVariables));
-        original.EnvironmentVariables.Should().NotBeEquivalentTo(modified.EnvironmentVariables);
+        modified.Should().BeSameAs(original);
         modified
             .EnvironmentVariables.Should()
             .BeEquivalentTo(
@@ -251,8 +240,7 @@ public class ConfigurationSpecs
         var modified = original.WithValidation(CommandResultValidation.None);
 
         // Assert
-        original.Should().BeEquivalentTo(modified, o => o.Excluding(c => c.Validation));
-        original.Validation.Should().NotBe(modified.Validation);
+        modified.Should().BeSameAs(original);
         modified.Validation.Should().Be(CommandResultValidation.None);
     }
 
@@ -263,11 +251,12 @@ public class ConfigurationSpecs
         var original = Cli.Wrap("foo").WithStandardInputPipe(PipeSource.Null);
 
         // Act
-        var modified = original.WithStandardInputPipe(PipeSource.FromString("new"));
+        var modifiedPipeSource = PipeSource.FromString("new");
+        var modified = original.WithStandardInputPipe(modifiedPipeSource);
 
         // Assert
-        original.Should().BeEquivalentTo(modified, o => o.Excluding(c => c.StandardInputPipe));
-        original.StandardInputPipe.Should().NotBeSameAs(modified.StandardInputPipe);
+        modified.Should().BeSameAs(original);
+        modified.StandardInputPipe.Should().BeSameAs(modifiedPipeSource);
     }
 
     [Fact]
@@ -277,11 +266,12 @@ public class ConfigurationSpecs
         var original = Cli.Wrap("foo").WithStandardOutputPipe(PipeTarget.Null);
 
         // Act
-        var modified = original.WithStandardOutputPipe(PipeTarget.ToStream(Stream.Null));
+        var modifiedPipeTarget = PipeTarget.ToStream(Stream.Null);
+        var modified = original.WithStandardOutputPipe(modifiedPipeTarget);
 
         // Assert
-        original.Should().BeEquivalentTo(modified, o => o.Excluding(c => c.StandardOutputPipe));
-        original.StandardOutputPipe.Should().NotBeSameAs(modified.StandardOutputPipe);
+        modified.Should().BeSameAs(original);
+        modified.StandardOutputPipe.Should().BeSameAs(modifiedPipeTarget);
     }
 
     [Fact]
@@ -291,10 +281,11 @@ public class ConfigurationSpecs
         var original = Cli.Wrap("foo").WithStandardErrorPipe(PipeTarget.Null);
 
         // Act
-        var modified = original.WithStandardErrorPipe(PipeTarget.ToStream(Stream.Null));
+        var modifiedPipeTarget = PipeTarget.ToStream(Stream.Null);
+        var modified = original.WithStandardErrorPipe(modifiedPipeTarget);
 
         // Assert
-        original.Should().BeEquivalentTo(modified, o => o.Excluding(c => c.StandardErrorPipe));
-        original.StandardErrorPipe.Should().NotBeSameAs(modified.StandardErrorPipe);
+        modified.Should().BeSameAs(original);
+        modified.StandardErrorPipe.Should().BeSameAs(modifiedPipeTarget);
     }
 }

--- a/CliWrap.Tests/ValidationSpecs.cs
+++ b/CliWrap.Tests/ValidationSpecs.cs
@@ -21,7 +21,7 @@ public class ValidationSpecs(ITestOutputHelper testOutput)
         );
 
         ex.ExitCode.Should().Be(1);
-        ex.Command.Should().BeEquivalentTo(cmd);
+        ex.Command.Should().BeEquivalentTo(cmd.Configuration);
 
         testOutput.WriteLine(ex.ToString());
     }
@@ -39,7 +39,7 @@ public class ValidationSpecs(ITestOutputHelper testOutput)
 
         ex.Message.Should().Contain("Exit code set to 1"); // expected stderr
         ex.ExitCode.Should().Be(1);
-        ex.Command.Should().BeEquivalentTo(cmd);
+        ex.Command.Should().BeEquivalentTo(cmd.Configuration);
 
         testOutput.WriteLine(ex.ToString());
     }

--- a/CliWrap/Command.Execution.cs
+++ b/CliWrap/Command.Execution.cs
@@ -77,7 +77,7 @@ public partial class Command
 	/// <summary>
 	/// Creates and configures a new <see cref="ProcessStartInfo" /> instance for executing the command.
 	/// </summary>
-    protected ProcessStartInfo CreateStartInfo()
+    protected virtual ProcessStartInfo CreateStartInfo()
     {
         var startInfo = new ProcessStartInfo
         {

--- a/CliWrap/Command.Execution.cs
+++ b/CliWrap/Command.Execution.cs
@@ -74,9 +74,9 @@ public partial class Command
             ).FirstOrDefault(File.Exists) ?? TargetFilePath;
     }
 
-	/// <summary>
-	/// Creates and configures a new <see cref="ProcessStartInfo" /> instance for executing the command.
-	/// </summary>
+    /// <summary>
+    /// Creates and configures a new <see cref="ProcessStartInfo" /> instance for executing the command.
+    /// </summary>
     protected virtual ProcessStartInfo CreateStartInfo()
     {
         var startInfo = new ProcessStartInfo

--- a/CliWrap/Command.Execution.cs
+++ b/CliWrap/Command.Execution.cs
@@ -74,7 +74,10 @@ public partial class Command
             ).FirstOrDefault(File.Exists) ?? TargetFilePath;
     }
 
-    private ProcessStartInfo CreateStartInfo()
+	/// <summary>
+	/// Creates and configures a new <see cref="ProcessStartInfo" /> instance for executing the command.
+	/// </summary>
+    protected ProcessStartInfo CreateStartInfo()
     {
         var startInfo = new ProcessStartInfo
         {

--- a/CliWrap/CommandConfiguration.cs
+++ b/CliWrap/CommandConfiguration.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.IO;
+
+namespace CliWrap;
+
+record struct CommandConfiguration(
+    string TargetFilePath,
+    string Arguments,
+    string WorkingDirPath,
+    ResourcePolicy ResourcePolicy,
+    Credentials Credentials,
+    IReadOnlyDictionary<string, string?> EnvironmentVariables,
+    CommandResultValidation Validation,
+    PipeSource StandardInputPipe,
+    PipeTarget StandardOutputPipe,
+    PipeTarget StandardErrorPipe
+) : ICommandConfiguration
+{
+    public CommandConfiguration(string targetFilePath)
+        : this(
+            targetFilePath,
+            string.Empty,
+            Directory.GetCurrentDirectory(),
+            ResourcePolicy.Default,
+            Credentials.Default,
+            new Dictionary<string, string?>(),
+            CommandResultValidation.ZeroExitCode,
+            PipeSource.Null,
+            PipeTarget.Null,
+            PipeTarget.Null
+        ) { }
+}

--- a/CliWrap/Utils/ProcessEx.cs
+++ b/CliWrap/Utils/ProcessEx.cs
@@ -26,11 +26,11 @@ internal class ProcessEx(ProcessStartInfo startInfo) : IDisposable
     // We are purposely using Stream instead of StreamWriter/StreamReader to push the concerns of
     // writing and reading to PipeSource/PipeTarget at the higher level.
 
-    public Stream StandardInput => _nativeProcess.StandardInput.BaseStream;
+    public Stream StandardInput => _nativeProcess.StartInfo.RedirectStandardInput ? _nativeProcess.StandardInput.BaseStream : Stream.Null;
 
-    public Stream StandardOutput => _nativeProcess.StandardOutput.BaseStream;
+    public Stream StandardOutput => _nativeProcess.StartInfo.RedirectStandardOutput ? _nativeProcess.StandardOutput.BaseStream : Stream.Null;
 
-    public Stream StandardError => _nativeProcess.StandardError.BaseStream;
+    public Stream StandardError => _nativeProcess.StartInfo.RedirectStandardError ? _nativeProcess.StandardError.BaseStream : Stream.Null;
 
     // We have to keep track of StartTime ourselves because it becomes inaccessible after the process exits
     // https://github.com/Tyrrrz/CliWrap/issues/93

--- a/CliWrap/Utils/ProcessEx.cs
+++ b/CliWrap/Utils/ProcessEx.cs
@@ -26,11 +26,20 @@ internal class ProcessEx(ProcessStartInfo startInfo) : IDisposable
     // We are purposely using Stream instead of StreamWriter/StreamReader to push the concerns of
     // writing and reading to PipeSource/PipeTarget at the higher level.
 
-    public Stream StandardInput => _nativeProcess.StartInfo.RedirectStandardInput ? _nativeProcess.StandardInput.BaseStream : Stream.Null;
+    public Stream StandardInput =>
+        _nativeProcess.StartInfo.RedirectStandardInput
+            ? _nativeProcess.StandardInput.BaseStream
+            : Stream.Null;
 
-    public Stream StandardOutput => _nativeProcess.StartInfo.RedirectStandardOutput ? _nativeProcess.StandardOutput.BaseStream : Stream.Null;
+    public Stream StandardOutput =>
+        _nativeProcess.StartInfo.RedirectStandardOutput
+            ? _nativeProcess.StandardOutput.BaseStream
+            : Stream.Null;
 
-    public Stream StandardError => _nativeProcess.StartInfo.RedirectStandardError ? _nativeProcess.StandardError.BaseStream : Stream.Null;
+    public Stream StandardError =>
+        _nativeProcess.StartInfo.RedirectStandardError
+            ? _nativeProcess.StandardError.BaseStream
+            : Stream.Null;
 
     // We have to keep track of StartTime ourselves because it becomes inaccessible after the process exits
     // https://github.com/Tyrrrz/CliWrap/issues/93


### PR DESCRIPTION
Summary of changes:

- Makes `Command` inheritable by changing the implementation of the fluent configuration API
    - Instead of directly instantiating new `Command` instances, the fluent configuration API now delegates to a contained immutable `CommandConfiguration` struct. This preserves the immutability and atomicity of the configuration (and the resulting thread safety) while allowing the `Command` object to be reconfigured.
- Adds additional constructors to `Command` and clarifies their xmldocs
- Ensures the contained `CommandConfiguration` is always copied to a local variable up-front to protect against any concurrent modifications
- Changes accessibility of `Command.CreateStartInfo()` from `private` to `protected virtual` to allow derived classes to customize how the `ProcessStartInfo` is configured
- Fixes `StandardInput`, `StandardOutput`, and `StandardError` properties on `ProcessEx` to return `Stream.Null` when not redirected
- Updates unit tests accordingly (all tests are passing)

To avoid any breaking changes, `Command` still implements `ICommandConfiguration` but now delegates the implementation to the contained `CommandConfiguration` instance. This should be removed in next major, and applications should instead use the new `Command.Configuration` property.

Closes https://github.com/Tyrrrz/CliWrap/issues/79