### PR TITLE
Add `Command.ExecuteAsync(...)` overload that allows direct manipulation of `ProcessStartInfo`/`Process`

### DIFF
--- a/CliWrap.Tests/ExecutionSpecs.cs
+++ b/CliWrap.Tests/ExecutionSpecs.cs
@@ -49,6 +49,22 @@ public class ExecutionSpecs
     }
 
     [Fact(Timeout = 15000)]
+    public async Task I_can_execute_a_command_with_manually_configured_process_settings()
+    {
+        // Arrange
+        var cmd = Cli.Wrap(Dummy.Program.FilePath).WithValidation(CommandResultValidation.None);
+
+        // Act
+        var result = await cmd.ExecuteAsync(
+            startInfo => startInfo.Arguments = "exit 13",
+            process => process.PriorityBoostEnabled = false
+        );
+
+        // Assert
+        result.ExitCode.Should().Be(13);
+    }
+
+    [Fact(Timeout = 15000)]
     public async Task I_can_execute_a_command_and_not_hang_on_large_stdout_and_stderr()
     {
         // Arrange

--- a/CliWrap/Command.Execution.cs
+++ b/CliWrap/Command.Execution.cs
@@ -308,7 +308,7 @@ public partial class Command
     // https://github.com/Tyrrrz/CliWrap/issues/79
     public CommandTask<CommandResult> ExecuteAsync(
         Action<ProcessStartInfo>? configureStartInfo,
-        Action<Process>? configureProcess,
+        Action<Process>? configureProcess = null,
         CancellationToken forcefulCancellationToken = default,
         CancellationToken gracefulCancellationToken = default
     )

--- a/CliWrap/Command.Execution.cs
+++ b/CliWrap/Command.Execution.cs
@@ -296,17 +296,27 @@ public partial class Command
 
     /// <summary>
     /// Executes the command asynchronously.
+    /// This overload allows you to directly configure the underlying process, and should
+    /// only be used in rare cases when you need to break out of the abstraction model
+    /// provided by CliWrap.
+    /// This overload comes with no warranty and using it may lead to unexpected behavior.
     /// </summary>
     /// <remarks>
     /// This method can be awaited.
     /// </remarks>
-    // TODO: (breaking change) use optional parameters and remove the other overload
+    // Added to facilitate running the command without redirecting some/all of the streams
+    // https://github.com/Tyrrrz/CliWrap/issues/79
     public CommandTask<CommandResult> ExecuteAsync(
-        CancellationToken forcefulCancellationToken,
-        CancellationToken gracefulCancellationToken
+        Action<ProcessStartInfo>? configureStartInfo,
+        Action<Process>? configureProcess,
+        CancellationToken forcefulCancellationToken = default,
+        CancellationToken gracefulCancellationToken = default
     )
     {
-        var process = new ProcessEx(CreateStartInfo());
+        var startInfo = CreateStartInfo();
+        configureStartInfo?.Invoke(startInfo);
+
+        var process = new ProcessEx(startInfo);
 
         // This method may fail, and we want to propagate the exceptions immediately instead
         // of wrapping them in a task, so it needs to be executed in a synchronous context.
@@ -343,6 +353,8 @@ public partial class Command
                 // This exception could indicate that the process has exited before we had a chance to set the policy.
                 // This is not an exceptional situation, so we don't need to do anything here.
             }
+
+            configureProcess?.Invoke(p);
         });
 
         // Extract the process ID before calling ExecuteAsync(), because the process may
@@ -354,6 +366,18 @@ public partial class Command
             processId
         );
     }
+
+    /// <summary>
+    /// Executes the command asynchronously.
+    /// </summary>
+    /// <remarks>
+    /// This method can be awaited.
+    /// </remarks>
+    // TODO: (breaking change) use optional parameters and remove the other overload
+    public CommandTask<CommandResult> ExecuteAsync(
+        CancellationToken forcefulCancellationToken,
+        CancellationToken gracefulCancellationToken
+    ) => ExecuteAsync(null, null, forcefulCancellationToken, gracefulCancellationToken);
 
     /// <summary>
     /// Executes the command asynchronously.


### PR DESCRIPTION
Closes #79

Example usage:

```csharp
var cmd = Cli.Wrap(...);

var result = await cmd.ExecuteAsync(
    startInfo =>
    {
        startInfo.RedirectStandardInput = false;
        startInfo.RedirectStandardOutput = false;
        startInfo.RedirectStandardError = false;
        startInfo.CreateNoWindow = false;
    },
    process =>
    {
        process.PriorityBoostEnabled = true;
    }
);
```

Note that using this overload is reserved for very rare edge cases where you need to break out of CliWrap's abstraction model (such as #79) and configure the low-level process properties/behavior manually. Do not rely on it in the general case.

If something breaks when using this overload, you're on your own.