### PR TITLE
Drop official support for .NET Framework

### DIFF
--- a/CliWrap.Tests.Dummy/CliWrap.Tests.Dummy.csproj
+++ b/CliWrap.Tests.Dummy/CliWrap.Tests.Dummy.csproj
@@ -1,15 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net9.0</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))"
-      >$(TargetFrameworks);net48</TargetFrameworks
-    >
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CliFx" Version="2.3.6" />
     <PackageReference Include="CSharpier.MsBuild" Version="1.0.2" PrivateAssets="all" />
-    <PackageReference Include="PolyShim" Version="1.15.0" PrivateAssets="all" />
-    <PackageReference Include="System.Memory" Version="4.6.3" />
   </ItemGroup>
 </Project>

--- a/CliWrap.Tests/CliWrap.Tests.csproj
+++ b/CliWrap.Tests/CliWrap.Tests.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))"
-      >$(TargetFrameworks);net48</TargetFrameworks
-    >
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />

--- a/CliWrap/CliWrap.csproj
+++ b/CliWrap/CliWrap.csproj
@@ -27,15 +27,15 @@
     <PackageReference Include="CSharpier.MsBuild" Version="1.0.2" PrivateAssets="all" />
     <PackageReference
       Include="Microsoft.Bcl.AsyncInterfaces"
-      Version="9.0.1"
-      Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netstandard2.1')) != true"
+      Version="9.0.5"
+      Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netstandard2.1'))"
     />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
     <PackageReference Include="PolyShim" Version="1.15.0" PrivateAssets="all" />
     <PackageReference
       Include="System.Threading.Tasks.Extensions"
-      Version="4.5.4"
-      Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netstandard2.1')) != true"
+      Version="4.6.3"
+      Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netstandard2.1'))"
     />
     <PackageReference
       Include="System.Management"
@@ -45,11 +45,8 @@
     <PackageReference
       Include="System.Memory"
       Version="4.6.0"
-      Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netstandard2.1')) != true"
+      Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netstandard2.1'))"
     />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-    <Reference Include="System.Management" />
   </ItemGroup>
   <!-- Non-linking dependency on the signaler project to ensure correct build order -->
   <ItemGroup>

--- a/CliWrap/CliWrap.csproj
+++ b/CliWrap/CliWrap.csproj
@@ -40,7 +40,7 @@
     <PackageReference
       Include="System.Management"
       Version="9.0.1"
-      Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'"
+      Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netcoreapp3.0'))"
     />
     <PackageReference
       Include="System.Memory"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <!-- Disable nullability warnings on older frameworks because there is no nullability info for BCL -->
-  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netstandard2.1')) != true">
+  <PropertyGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netstandard2.1'))">
     <Nullable>annotations</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
Supporting .NET Framework in CliWrap has started taking up too much effort. Considering that .NET Framework is legacy technology at this point and .NET (Core) is pretty much as mature as it gets (having been out for 9+ years), I see no reason to justify the effort to maintain official support for .NET Framework in this library.

Users can still continue to use CliWrap with .NET Framework, however they will need to figure out any run-time compatibility issues themselves. CliWrap will continue targeting .NET Standard 2.0 which should ensure compatibility with .NET Framework on paper (and, as experience shows, only on paper).

This PR removes tests running against .NET Fx and updates package references that previously caused compatibility issues. It also removes a framework reference on `System.Management`.