### PR TITLE
Add new PipeTarget.ToFile overload with more parameters

### DIFF
--- a/CliWrap/PipeSource.cs
+++ b/CliWrap/PipeSource.cs
@@ -72,19 +72,27 @@ public partial class PipeSource
     /// <summary>
     /// Creates a pipe source that reads from the specified stream.
     /// </summary>
-    public static PipeSource FromStream(Stream stream, bool autoFlush) =>
+    public static PipeSource FromStream(
+        Stream stream,
+        bool autoFlush = true,
+        bool disposeStream = false
+    ) =>
         Create(
             async (destination, cancellationToken) =>
-                await stream
-                    .CopyToAsync(destination, autoFlush, cancellationToken)
-                    .ConfigureAwait(false)
+            {
+                try
+                {
+                    await stream
+                        .CopyToAsync(destination, autoFlush, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                finally
+                {
+                    if (disposeStream)
+                        await stream.DisposeAsync().ConfigureAwait(false);
+                }
+            }
         );
-
-    /// <summary>
-    /// Creates a pipe source that reads from the specified stream.
-    /// </summary>
-    // TODO: (breaking change) remove in favor of optional parameter
-    public static PipeSource FromStream(Stream stream) => FromStream(stream, true);
 
     /// <summary>
     /// Creates a pipe source that reads from the specified file.

--- a/CliWrap/PipeTarget.cs
+++ b/CliWrap/PipeTarget.cs
@@ -184,25 +184,12 @@ public partial class PipeTarget
     /// <summary>
     /// Creates a pipe target that writes to the specified file.
     /// </summary>
-    public static PipeTarget ToFile(string filePath) =>
-        Create(
-            async (origin, cancellationToken) =>
-            {
-                var target = File.Create(filePath);
-                await using (target.ToAsyncDisposable())
-                    await origin.CopyToAsync(target, cancellationToken).ConfigureAwait(false);
-            }
-        );
-
-    /// <summary>
-    /// Creates a pipe target that writes to the specified file.
-    /// </summary>
     public static PipeTarget ToFile(
         string filePath,
         FileMode mode = FileMode.Create,
         FileShare share = FileShare.Read,
         int bufferSize = 4096,
-        FileOptions options = FileOptions.WriteThrough,
+        FileOptions options = FileOptions.None,
         bool autoFlush = true
     ) =>
         Create(

--- a/CliWrap/PipeTarget.cs
+++ b/CliWrap/PipeTarget.cs
@@ -195,8 +195,17 @@ public partial class PipeTarget
         Create(
             async (origin, cancellationToken) =>
             {
-                using var target = new FileStream(filePath, mode, FileAccess.Write, share, bufferSize, options);
-                await origin.CopyToAsync(target, autoFlush, cancellationToken).ConfigureAwait(false);
+                using var target = new FileStream(
+                    filePath,
+                    mode,
+                    FileAccess.Write,
+                    share,
+                    bufferSize,
+                    options
+                );
+                await origin
+                    .CopyToAsync(target, autoFlush, cancellationToken)
+                    .ConfigureAwait(false);
             }
         );
 

--- a/CliWrap/PipeTarget.cs
+++ b/CliWrap/PipeTarget.cs
@@ -195,6 +195,25 @@ public partial class PipeTarget
         );
 
     /// <summary>
+    /// Creates a pipe target that writes to the specified file.
+    /// </summary>
+    public static PipeTarget ToFile(
+        string filePath,
+        FileMode mode = FileMode.Create,
+        FileShare share = FileShare.Read,
+        int bufferSize = 4096,
+        FileOptions options = FileOptions.WriteThrough,
+        bool autoFlush = true
+    ) =>
+        Create(
+            async (origin, cancellationToken) =>
+            {
+                using var target = new FileStream(filePath, mode, FileAccess.Write, share, bufferSize, options);
+                await origin.CopyToAsync(target, autoFlush, cancellationToken).ConfigureAwait(false);
+            }
+        );
+
+    /// <summary>
     /// Creates a pipe target that writes to the specified string builder.
     /// </summary>
     public static PipeTarget ToStringBuilder(StringBuilder stringBuilder, Encoding encoding) =>

--- a/CliWrap/PipeTarget.cs
+++ b/CliWrap/PipeTarget.cs
@@ -136,7 +136,7 @@ public partial class PipeTarget
     /// In the vast majority of cases, this behavior should be functionally equivalent to piping
     /// to a null stream, but without the performance overhead of consuming and discarding unneeded data.
     /// This may be undesirable in certain situations, in which case it's recommended to pipe to a
-    /// null stream explicitly using <see cref="ToStream(Stream)" /> with <see cref="Stream.Null" />.
+    /// null stream explicitly using <see cref="ToStream(Stream, bool, bool)" /> with <see cref="Stream.Null" />.
     /// </remarks>
     public static PipeTarget Null { get; } =
         Create(
@@ -169,43 +169,42 @@ public partial class PipeTarget
     /// <summary>
     /// Creates a pipe target that writes to the specified stream.
     /// </summary>
-    public static PipeTarget ToStream(Stream stream, bool autoFlush) =>
+    public static PipeTarget ToStream(
+        Stream stream,
+        bool autoFlush = true,
+        bool disposeStream = false
+    ) =>
         Create(
             async (origin, cancellationToken) =>
-                await origin.CopyToAsync(stream, autoFlush, cancellationToken).ConfigureAwait(false)
+            {
+                try
+                {
+                    await origin
+                        .CopyToAsync(stream, autoFlush, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                finally
+                {
+                    if (disposeStream)
+                        await stream.DisposeAsync().ConfigureAwait(false);
+                }
+            }
         );
-
-    /// <summary>
-    /// Creates a pipe target that writes to the specified stream.
-    /// </summary>
-    // TODO: (breaking change) remove in favor of optional parameter
-    public static PipeTarget ToStream(Stream stream) => ToStream(stream, true);
 
     /// <summary>
     /// Creates a pipe target that writes to the specified file.
     /// </summary>
-    public static PipeTarget ToFile(
-        string filePath,
-        FileMode mode = FileMode.Create,
-        FileShare share = FileShare.Read,
-        int bufferSize = 4096,
-        FileOptions options = FileOptions.None,
-        bool autoFlush = true
-    ) =>
+    public static PipeTarget ToFile(string filePath) =>
         Create(
             async (origin, cancellationToken) =>
             {
                 using var target = new FileStream(
                     filePath,
-                    mode,
+                    FileMode.Create,
                     FileAccess.Write,
-                    share,
-                    bufferSize,
-                    options
+                    FileShare.Read
                 );
-                await origin
-                    .CopyToAsync(target, autoFlush, cancellationToken)
-                    .ConfigureAwait(false);
+                await origin.CopyToAsync(target, true, cancellationToken).ConfigureAwait(false);
             }
         );
 


### PR DESCRIPTION
<!--

**Important**

This pull request should be linked to an issue that describes the problem it addresses.
If there is no corresponding issue yet, please create one first.

An open issue provides a good place to iron out technical requirements and discuss potential solutions.
Creating a pull request without prior discussion may very likely lead to wasted effort.

-->

<!-- Please specify the issue(s) addressed by this pull request: -->

Closes #331

<!--

Also keep in mind:

- Pull requests should be as small as possible. Split larger changes into multiple pull requests if needed.
- Follow the coding style and conventions already established in the project. When in doubt, ask in the comments.
- You can add review comments to your own code. Use this to highlight something important or to seek further input from reviewers.

-->

I am not entirely sure if I correctly understand the meaning of 'update the default file settings'. I think it is worth noting that avoiding caching may potentially lead to a loss in performance. Additionally, I referred to the current implementation of `ToStream(bool autoFlush)`, and I wonder if we might want to avoid breaking binary compatibility?

Therefore, I have opted to simply add a new overload for now; if you believe the original `ToFile` could be modified directly, we can adjust it further.