### PR TITLE
Fix a race condition inside PullEventStream

### DIFF
--- a/CliWrap.Tests/CancellationSpecs.cs
+++ b/CliWrap.Tests/CancellationSpecs.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reactive.Linq;
 using System.Text;
@@ -181,6 +182,59 @@ public class CancellationSpecs
         (await act.Should().ThrowAsync<OperationCanceledException>())
             .Which.CancellationToken.Should()
             .Be(cts.Token);
+    }
+
+    [Fact(Timeout = 15000)]
+    public async Task I_can_execute_a_command_as_a_pull_based_event_stream_with_no_unobserved_exception()
+    {
+        // Arrange
+        var unobservedExceptions = new List<Exception>();
+
+        void OnUnobservedException(object? sender, UnobservedTaskExceptionEventArgs e)
+        {
+            unobservedExceptions.Add(e.Exception);
+            e.SetObserved();
+        }
+
+        TaskScheduler.UnobservedTaskException += OnUnobservedException;
+
+        var cmd = Cli.Wrap("dotnet").WithArguments(["--version"]);
+
+        // Act
+        try
+        {
+            // Repeat to maximize race condition triggering
+            for (var i = 0; i < 50; i++)
+            {
+                using var cts = new CancellationTokenSource();
+
+                var act = Task.Run(async () =>
+                {
+                    try
+                    {
+                        await foreach (var _ in cmd.ListenAsync(cts.Token))
+                        {
+                            cts.Cancel();
+                        }
+                    }
+                    catch (OperationCanceledException) { }
+                });
+
+                await act;
+            }
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+            await Task.Delay(500);
+        }
+        finally
+        {
+            TaskScheduler.UnobservedTaskException -= OnUnobservedException;
+        }
+
+        // Assert
+        Assert.Empty(unobservedExceptions);
     }
 
     [Fact(Timeout = 15000)]

--- a/CliWrap.Tests/CancellationSpecs.cs
+++ b/CliWrap.Tests/CancellationSpecs.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reactive.Linq;
 using System.Text;
@@ -188,7 +188,7 @@ public class CancellationSpecs
     public async Task I_can_execute_a_command_as_a_pull_based_event_stream_with_no_unobserved_exception()
     {
         // Arrange
-        var unobservedExceptions = new List<Exception>();
+        var unobservedExceptions = new ConcurrentBag<Exception>();
 
         void OnUnobservedException(object? sender, UnobservedTaskExceptionEventArgs e)
         {
@@ -201,14 +201,15 @@ public class CancellationSpecs
         var cmd = Cli.Wrap("dotnet").WithArguments(["--version"]);
 
         // Act
+        // Listening to a pull event stream followed by cancelling the listening, should no trigger any UnobservedTaskException
+        // Since the issue is a race condition, run the operation multiple times and concurently to maximize the chances of triggering it
         try
         {
-            // Repeat to maximize race condition triggering
             for (var i = 0; i < 50; i++)
             {
                 using var cts = new CancellationTokenSource();
 
-                var act = Task.Run(async () =>
+                await Task.Run(async () =>
                 {
                     try
                     {
@@ -219,8 +220,6 @@ public class CancellationSpecs
                     }
                     catch (OperationCanceledException) { }
                 });
-
-                await act;
             }
 
             GC.Collect();
@@ -234,7 +233,7 @@ public class CancellationSpecs
         }
 
         // Assert
-        Assert.Empty(unobservedExceptions);
+        unobservedExceptions.Should().BeEmpty();
     }
 
     [Fact(Timeout = 15000)]

--- a/CliWrap/EventStream/PullEventStreamCommandExtensions.cs
+++ b/CliWrap/EventStream/PullEventStreamCommandExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -75,23 +76,39 @@ public static partial class EventStreamCommandExtensions
 
             yield return new StartedCommandEvent(commandTask.ProcessId);
 
-            // Close the channel once the command completes, so that ReceiveAsync() can finish
-            _ = commandTask.Task.ContinueWith(
-                async _ =>
-                    await channel
-                        .ReportCompletionAsync(forcefulCancellationToken)
-                        .ConfigureAwait(false),
-                // Run the continuation even if the parent task failed
-                TaskContinuationOptions.None
-            );
+            var completionTask = commandTask
+                .Task.ContinueWith(
+                    async _ =>
+                        await channel
+                            .ReportCompletionAsync(forcefulCancellationToken)
+                            .ConfigureAwait(false),
+                    // Run the continuation even if the parent task failed
+                    TaskContinuationOptions.None
+                )
+                .Unwrap();
 
-            await foreach (
-                var cmdEvent in channel
-                    .ReceiveAsync(forcefulCancellationToken)
-                    .ConfigureAwait(false)
-            )
+            try
             {
-                yield return cmdEvent;
+                await foreach (
+                    var cmdEvent in channel
+                        .ReceiveAsync(forcefulCancellationToken)
+                        .ConfigureAwait(false)
+                )
+                {
+                    yield return cmdEvent;
+                }
+            }
+            finally
+            {
+                try
+                {
+                    await completionTask.ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                    when (ex is OperationCanceledException or ObjectDisposedException)
+                {
+                    // Channel already close
+                }
             }
 
             var result = await commandTask.ConfigureAwait(false);

--- a/CliWrap/EventStream/PullEventStreamCommandExtensions.cs
+++ b/CliWrap/EventStream/PullEventStreamCommandExtensions.cs
@@ -107,7 +107,7 @@ public static partial class EventStreamCommandExtensions
                 catch (Exception ex)
                     when (ex is OperationCanceledException or ObjectDisposedException)
                 {
-                    // Channel already close
+                    // Channel has already closed
                 }
             }
 


### PR DESCRIPTION
In the ListenAsync method in EventStreamCommandExtensions class there is a fire-and-forget continuation to close the channel on command completion.
But there is a race condition here if the operation is cancelled or the channel is already disposed before the continuation run.
This will cause either an OperationCanceledException or an ObjectDisposedException to be throw during Garbage Collector finalize.
To prevent that explicitly wait the continuation task and catch OperationCanceledException or ObjectDisposedException.

Close #336