### PR TITLE
Fix issues with runaway tasks and broken iterators

### DIFF
--- a/CliWrap.Benchmarks/BufferingBenchmarks.cs
+++ b/CliWrap.Benchmarks/BufferingBenchmarks.cs
@@ -14,7 +14,7 @@ public class BufferingBenchmarks
     public async Task<(string, string)> CliWrap()
     {
         var result = await Cli.Wrap(Tests.Dummy.Program.FilePath)
-            .WithArguments(["generate", "text", "--lines", "1000"])
+            .WithArguments(["generate", "text", "--length", "100000000", "--lines", "1000"])
             .ExecuteBufferedAsync();
 
         return (result.StandardOutput, result.StandardError);
@@ -25,7 +25,7 @@ public class BufferingBenchmarks
     {
         var result = await ProcessEx.RunAsync(
             Tests.Dummy.Program.FilePath,
-            "generate text --lines 1000"
+            "generate text --length 100000000 --lines 1000"
         );
 
         return (
@@ -40,7 +40,7 @@ public class BufferingBenchmarks
         var result = await Medallion
             .Shell.Shell.Default.Run(
                 Tests.Dummy.Program.FilePath,
-                ["generate", "text", "--lines", "1000"]
+                ["generate", "text", "--length", "100000000", "--lines", "1000"]
             )
             .Task;
 
@@ -52,7 +52,7 @@ public class BufferingBenchmarks
     {
         var (_, stdOutStream, stdErrStream) = Cysharp.Diagnostics.ProcessX.GetDualAsyncEnumerable(
             Tests.Dummy.Program.FilePath,
-            arguments: "generate text --lines 1000"
+            arguments: "generate text --length 100000000 --lines 1000"
         );
 
         var stdOutTask = stdOutStream.ToTask();

--- a/CliWrap.Benchmarks/PullEventStreamBenchmarks.cs
+++ b/CliWrap.Benchmarks/PullEventStreamBenchmarks.cs
@@ -15,7 +15,7 @@ public class PullEventStreamBenchmarks
 
         await foreach (
             var cmdEvent in Cli.Wrap(Tests.Dummy.Program.FilePath)
-                .WithArguments(["generate", "text", "--lines", "1000"])
+                .WithArguments(["generate", "text", "--length", "100000000", "--lines", "1000"])
                 .ListenAsync()
         )
         {
@@ -40,7 +40,7 @@ public class PullEventStreamBenchmarks
 
         var (_, stdOutStream, stdErrStream) = Cysharp.Diagnostics.ProcessX.GetDualAsyncEnumerable(
             Tests.Dummy.Program.FilePath,
-            arguments: "generate text --lines 1000"
+            arguments: "generate text --length 100000000 --lines 1000"
         );
 
         var consumeStdOutTask = Task.Run(async () =>

--- a/CliWrap.Benchmarks/PushEventStreamBenchmarks.cs
+++ b/CliWrap.Benchmarks/PushEventStreamBenchmarks.cs
@@ -15,7 +15,7 @@ public class PushEventStreamBenchmarks
         var counter = 0;
 
         await Cli.Wrap(Tests.Dummy.Program.FilePath)
-            .WithArguments(["generate", "text", "--lines", "1000"])
+            .WithArguments(["generate", "text", "--length", "100000000", "--lines", "1000"])
             .Observe()
             .ForEachAsync(cmdEvent =>
             {

--- a/CliWrap.Tests.Dummy/Commands/GenerateTextCommand.cs
+++ b/CliWrap.Tests.Dummy/Commands/GenerateTextCommand.cs
@@ -25,13 +25,25 @@ public partial class GenerateTextCommand : ICommand
     [CommandOption("lines")]
     public int LinesCount { get; set; } = 1;
 
+    private int LineLength => LinesCount > 0 ? Length / LinesCount : 0;
+
     public async ValueTask ExecuteAsync(IConsole console)
     {
+        if (LineLength <= 0)
+            return;
+
         for (var line = 0; line < LinesCount; line++)
         {
-            var buffer = new StringBuilder(Length);
+            var currentLineLength =
+                line < LinesCount - 1
+                    ? LineLength
+                    // Place any remaining characters in the last line so that the total output length
+                    // is always equal to Length.
+                    : Length - LineLength * line;
 
-            for (var i = 0; i < Length; i++)
+            var buffer = new StringBuilder(currentLineLength);
+
+            for (var i = 0; i < currentLineLength; i++)
             {
                 buffer.Append(_allowedChars[_random.Next(0, _allowedChars.Length)]);
             }

--- a/CliWrap.Tests.Dummy/Commands/GenerateTextCommand.cs
+++ b/CliWrap.Tests.Dummy/Commands/GenerateTextCommand.cs
@@ -29,10 +29,10 @@ public partial class GenerateTextCommand : ICommand
 
     public async ValueTask ExecuteAsync(IConsole console)
     {
-        var lineLength = LinesCount > 0 ? Length / LinesCount : 0;
-
-        if (lineLength <= 0)
+        if (Length <= 0 || LinesCount <= 0)
             return;
+
+        var lineLength = LinesCount > 0 ? Length / LinesCount : 0;
 
         for (var lineNumber = 0; lineNumber < LinesCount; lineNumber++)
         {

--- a/CliWrap.Tests.Dummy/Commands/GenerateTextCommand.cs
+++ b/CliWrap.Tests.Dummy/Commands/GenerateTextCommand.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using CliFx;
 using CliFx.Binding;
@@ -25,31 +24,26 @@ public partial class GenerateTextCommand : ICommand
     [CommandOption("lines")]
     public int LinesCount { get; set; } = 1;
 
-    private int LineLength => LinesCount > 0 ? Length / LinesCount : 0;
-
     public async ValueTask ExecuteAsync(IConsole console)
     {
-        if (LineLength <= 0)
+        var lineLength = LinesCount > 0 ? Length / LinesCount : 0;
+
+        if (lineLength <= 0)
             return;
 
-        for (var line = 0; line < LinesCount; line++)
+        for (var lineNumber = 0; lineNumber < LinesCount; lineNumber++)
         {
             var currentLineLength =
-                line < LinesCount - 1
-                    ? LineLength
+                lineNumber < LinesCount - 1
+                    ? lineLength
                     // Place any remaining characters in the last line so that the total output length
                     // is always equal to Length.
-                    : Length - LineLength * line;
+                    : Length - lineLength * lineNumber;
 
-            var buffer = new StringBuilder(currentLineLength);
-
-            for (var i = 0; i < currentLineLength; i++)
-            {
-                buffer.Append(_allowedChars[_random.Next(0, _allowedChars.Length)]);
-            }
+            var line = _random.GetItems(_allowedChars, currentLineLength);
 
             foreach (var writer in console.GetWriters(Target))
-                await writer.WriteLineAsync(buffer.ToString());
+                await writer.WriteLineAsync(new string(line));
         }
     }
 }

--- a/CliWrap.Tests.Dummy/Commands/GenerateTextCommand.cs
+++ b/CliWrap.Tests.Dummy/Commands/GenerateTextCommand.cs
@@ -13,7 +13,10 @@ public partial class GenerateTextCommand : ICommand
 {
     // Tests rely on the random seed being fixed
     private readonly Random _random = new(1234567);
-    private readonly char[] _allowedChars = Enumerable.Range(32, 94).Select(i => (char)i).ToArray();
+    private static readonly char[] AllowedChars = Enumerable
+        .Range(32, 94)
+        .Select(i => (char)i)
+        .ToArray();
 
     [CommandOption("target")]
     public OutputTarget Target { get; set; } = OutputTarget.StdOut;
@@ -40,10 +43,14 @@ public partial class GenerateTextCommand : ICommand
                     // is always equal to Length.
                     : Length - lineLength * lineNumber;
 
-            var line = _random.GetItems(_allowedChars, currentLineLength);
+            var line = string.Create(
+                currentLineLength,
+                _random,
+                (buffer, random) => random.GetItems(AllowedChars, buffer)
+            );
 
             foreach (var writer in console.GetWriters(Target))
-                await writer.WriteLineAsync(new string(line));
+                await writer.WriteLineAsync(line);
         }
     }
 }

--- a/CliWrap.Tests/CancellationSpecs.cs
+++ b/CliWrap.Tests/CancellationSpecs.cs
@@ -12,6 +12,7 @@ using Xunit;
 
 namespace CliWrap.Tests;
 
+[Collection(nameof(NonParallelCollection))]
 public class CancellationSpecs
 {
     [Fact(Timeout = 15000)]
@@ -181,6 +182,57 @@ public class CancellationSpecs
         (await act.Should().ThrowAsync<OperationCanceledException>())
             .Which.CancellationToken.Should()
             .Be(cts.Token);
+    }
+
+    [Fact(Timeout = 15000)]
+    public async Task I_can_execute_a_command_as_a_pull_based_event_stream_and_cancel_it_without_unobserved_exception()
+    {
+        // https://github.com/Tyrrrz/CliWrap/issues/336
+
+        // Arrange
+        var exception = default(Exception?);
+
+        void OnUnobservedException(object? sender, UnobservedTaskExceptionEventArgs args)
+        {
+            Interlocked.CompareExchange(ref exception, args.Exception, null);
+            args.SetObserved();
+        }
+
+        TaskScheduler.UnobservedTaskException += OnUnobservedException;
+
+        var cmd = Cli.Wrap("dotnet").WithArguments(["--version"]);
+
+        // Act
+        try
+        {
+            // This is not a deterministic test, so run it multiple times to increase exposure to the race condition
+            for (var i = 0; i < 50; i++)
+            {
+                using var cts = new CancellationTokenSource();
+
+                try
+                {
+                    await foreach (var _ in cmd.ListenAsync(cts.Token))
+                    {
+                        await cts.CancelAsync();
+                    }
+                }
+                catch (OperationCanceledException) { }
+            }
+
+            await Task.Delay(500);
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+        }
+        finally
+        {
+            TaskScheduler.UnobservedTaskException -= OnUnobservedException;
+        }
+
+        // Assert
+        Volatile.Read(ref exception).Should().BeNull();
     }
 
     [Fact(Timeout = 15000)]

--- a/CliWrap.Tests/CancellationSpecs.cs
+++ b/CliWrap.Tests/CancellationSpecs.cs
@@ -200,7 +200,7 @@ public class CancellationSpecs
 
         TaskScheduler.UnobservedTaskException += OnUnobservedException;
 
-        var cmd = Cli.Wrap("dotnet").WithArguments(["--version"]);
+        var cmd = Cli.Wrap(Dummy.Program.FilePath).WithArguments(["sleep", "00:00:20"]);
 
         // Act
         try

--- a/CliWrap.Tests/CancellationSpecs.cs
+++ b/CliWrap.Tests/CancellationSpecs.cs
@@ -12,7 +12,6 @@ using Xunit;
 
 namespace CliWrap.Tests;
 
-[Collection(nameof(NonParallelCollection))]
 public class CancellationSpecs
 {
     [Fact(Timeout = 15000)]

--- a/CliWrap.Tests/CancellationSpecs.cs
+++ b/CliWrap.Tests/CancellationSpecs.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reactive.Linq;
 using System.Text;
@@ -182,58 +181,6 @@ public class CancellationSpecs
         (await act.Should().ThrowAsync<OperationCanceledException>())
             .Which.CancellationToken.Should()
             .Be(cts.Token);
-    }
-
-    [Fact(Timeout = 15000)]
-    public async Task I_can_execute_a_command_as_a_pull_based_event_stream_with_no_unobserved_exception()
-    {
-        // Arrange
-        var unobservedExceptions = new ConcurrentBag<Exception>();
-
-        void OnUnobservedException(object? sender, UnobservedTaskExceptionEventArgs e)
-        {
-            unobservedExceptions.Add(e.Exception);
-            e.SetObserved();
-        }
-
-        TaskScheduler.UnobservedTaskException += OnUnobservedException;
-
-        var cmd = Cli.Wrap("dotnet").WithArguments(["--version"]);
-
-        // Act
-        // Listening to a pull event stream followed by cancelling the listening, should no trigger any UnobservedTaskException
-        // Since the issue is a race condition, run the operation multiple times and concurently to maximize the chances of triggering it
-        try
-        {
-            for (var i = 0; i < 50; i++)
-            {
-                using var cts = new CancellationTokenSource();
-
-                await Task.Run(async () =>
-                {
-                    try
-                    {
-                        await foreach (var _ in cmd.ListenAsync(cts.Token))
-                        {
-                            cts.Cancel();
-                        }
-                    }
-                    catch (OperationCanceledException) { }
-                });
-            }
-
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            GC.Collect();
-            await Task.Delay(500);
-        }
-        finally
-        {
-            TaskScheduler.UnobservedTaskException -= OnUnobservedException;
-        }
-
-        // Assert
-        unobservedExceptions.Should().BeEmpty();
     }
 
     [Fact(Timeout = 15000)]

--- a/CliWrap.Tests/EventStreamSpecs.cs
+++ b/CliWrap.Tests/EventStreamSpecs.cs
@@ -15,7 +15,7 @@ public class EventStreamSpecs
     {
         // Arrange
         var cmd = Cli.Wrap(Dummy.Program.FilePath)
-            .WithArguments(["generate text", "--target", "all", "--lines", "100"]);
+            .WithArguments(["generate text", "--target", "all", "--lines", "1000"]);
 
         // Act
         var events = new List<CommandEvent>();
@@ -25,10 +25,59 @@ public class EventStreamSpecs
         // Assert
         events.OfType<StartedCommandEvent>().Should().ContainSingle();
         events.OfType<StartedCommandEvent>().Single().ProcessId.Should().NotBe(0);
-        events.OfType<StandardOutputCommandEvent>().Should().HaveCount(100);
-        events.OfType<StandardErrorCommandEvent>().Should().HaveCount(100);
+        events.OfType<StandardOutputCommandEvent>().Should().HaveCount(1000);
+        events.OfType<StandardErrorCommandEvent>().Should().HaveCount(1000);
         events.OfType<ExitedCommandEvent>().Should().ContainSingle();
         events.OfType<ExitedCommandEvent>().Single().ExitCode.Should().Be(0);
+    }
+
+    [Fact(Timeout = 15000)]
+    public async Task I_can_execute_a_command_as_a_pull_based_event_stream_and_not_hang_on_large_stdout_and_stderr()
+    {
+        // Arrange
+        var cmd = Cli.Wrap(Dummy.Program.FilePath)
+            .WithArguments([
+                "generate text",
+                "--target",
+                "all",
+                "--length",
+                "10000000",
+                "--lines",
+                "1000",
+            ]);
+
+        // Act & assert
+        await foreach (var _ in cmd.ListenAsync())
+        {
+            // Drain the stream, see if the test times out
+        }
+    }
+
+    [Fact(Timeout = 15000)]
+    public async Task I_can_execute_a_command_as_a_pull_based_event_stream_and_not_hang_on_large_stdout_and_stderr_if_I_break_out_early()
+    {
+        // Arrange
+        var cmd = Cli.Wrap(Dummy.Program.FilePath)
+            .WithArguments([
+                "generate text",
+                "--target",
+                "all",
+                "--length",
+                "10000000",
+                "--lines",
+                "1000",
+            ]);
+
+        // Act
+        var i = 0;
+        await foreach (var _ in cmd.ListenAsync())
+        {
+            if (++i >= 10)
+                break;
+        }
+
+        // Assert
+        i.Should().Be(10);
     }
 
     [Fact(Timeout = 15000)]
@@ -36,7 +85,7 @@ public class EventStreamSpecs
     {
         // Arrange
         var cmd = Cli.Wrap(Dummy.Program.FilePath)
-            .WithArguments(["generate text", "--target", "all", "--lines", "100"]);
+            .WithArguments(["generate text", "--target", "all", "--lines", "1000"]);
 
         // Act
         var events = await cmd.Observe().ToArray();
@@ -44,9 +93,28 @@ public class EventStreamSpecs
         // Assert
         events.OfType<StartedCommandEvent>().Should().ContainSingle();
         events.OfType<StartedCommandEvent>().Single().ProcessId.Should().NotBe(0);
-        events.OfType<StandardOutputCommandEvent>().Should().HaveCount(100);
-        events.OfType<StandardErrorCommandEvent>().Should().HaveCount(100);
+        events.OfType<StandardOutputCommandEvent>().Should().HaveCount(1000);
+        events.OfType<StandardErrorCommandEvent>().Should().HaveCount(1000);
         events.OfType<ExitedCommandEvent>().Should().ContainSingle();
         events.OfType<ExitedCommandEvent>().Single().ExitCode.Should().Be(0);
+    }
+
+    [Fact(Timeout = 15000)]
+    public async Task I_can_execute_a_command_as_a_push_based_event_stream_and_not_hang_on_large_stdout_and_stderr()
+    {
+        // Arrange
+        var cmd = Cli.Wrap(Dummy.Program.FilePath)
+            .WithArguments([
+                "generate text",
+                "--target",
+                "all",
+                "--length",
+                "10000000",
+                "--lines",
+                "1000",
+            ]);
+
+        // Act & assert
+        await cmd.Observe().ToArray();
     }
 }

--- a/CliWrap.Tests/EventStreamSpecs.cs
+++ b/CliWrap.Tests/EventStreamSpecs.cs
@@ -32,7 +32,7 @@ public class EventStreamSpecs
     }
 
     [Fact(Timeout = 15000)]
-    public async Task I_can_stop_listening_to_a_pull_based_event_stream_early()
+    public async Task I_can_execute_a_command_as_a_pull_based_event_stream_and_break_out_early()
     {
         // Arrange
         var cmd = Cli.Wrap(Dummy.Program.FilePath)
@@ -42,7 +42,7 @@ public class EventStreamSpecs
         var i = 0;
         await foreach (var _ in cmd.ListenAsync())
         {
-            if (i++ >= 10)
+            if (++i >= 10)
                 break;
         }
 

--- a/CliWrap.Tests/EventStreamSpecs.cs
+++ b/CliWrap.Tests/EventStreamSpecs.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Linq;
@@ -31,51 +29,6 @@ public class EventStreamSpecs
         events.OfType<StandardErrorCommandEvent>().Should().HaveCount(100);
         events.OfType<ExitedCommandEvent>().Should().ContainSingle();
         events.OfType<ExitedCommandEvent>().Single().ExitCode.Should().Be(0);
-    }
-
-    [Fact(Timeout = 15000)]
-    public async Task I_can_stop_listening_to_a_pull_based_event_stream_early()
-    {
-        // https://github.com/Tyrrrz/CliWrap/issues/336
-
-        // Arrange
-        var unobservedExceptions = new ConcurrentBag<Exception>();
-
-        void OnUnobservedException(object? sender, UnobservedTaskExceptionEventArgs e)
-        {
-            unobservedExceptions.Add(e.Exception);
-            e.SetObserved();
-        }
-
-        TaskScheduler.UnobservedTaskException += OnUnobservedException;
-
-        // Keep the process alive after the iterator is disposed, so its completion continuation
-        // attempts to close the channel after enumeration has stopped.
-        var cmd = Cli.Wrap(Dummy.Program.FilePath).WithArguments(["sleep", "00:00:00.1"]);
-
-        // Act
-        try
-        {
-            for (var i = 0; i < 10; i++)
-            {
-                await foreach (var _ in cmd.ListenAsync())
-                {
-                    break;
-                }
-            }
-
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            GC.Collect();
-            await Task.Delay(500);
-        }
-        finally
-        {
-            TaskScheduler.UnobservedTaskException -= OnUnobservedException;
-        }
-
-        // Assert
-        unobservedExceptions.Should().BeEmpty();
     }
 
     [Fact(Timeout = 15000)]

--- a/CliWrap.Tests/EventStreamSpecs.cs
+++ b/CliWrap.Tests/EventStreamSpecs.cs
@@ -32,6 +32,25 @@ public class EventStreamSpecs
     }
 
     [Fact(Timeout = 15000)]
+    public async Task I_can_stop_listening_to_a_pull_based_event_stream_early()
+    {
+        // Arrange
+        var cmd = Cli.Wrap(Dummy.Program.FilePath)
+            .WithArguments(["generate text", "--target", "all", "--lines", "100"]);
+
+        // Act
+        var i = 0;
+        await foreach (var _ in cmd.ListenAsync())
+        {
+            if (i++ >= 10)
+                break;
+        }
+
+        // Assert
+        i.Should().Be(10);
+    }
+
+    [Fact(Timeout = 15000)]
     public async Task I_can_execute_a_command_as_a_push_based_event_stream()
     {
         // Arrange

--- a/CliWrap.Tests/EventStreamSpecs.cs
+++ b/CliWrap.Tests/EventStreamSpecs.cs
@@ -32,25 +32,6 @@ public class EventStreamSpecs
     }
 
     [Fact(Timeout = 15000)]
-    public async Task I_can_execute_a_command_as_a_pull_based_event_stream_and_break_out_early()
-    {
-        // Arrange
-        var cmd = Cli.Wrap(Dummy.Program.FilePath)
-            .WithArguments(["generate text", "--target", "all", "--lines", "100"]);
-
-        // Act
-        var i = 0;
-        await foreach (var _ in cmd.ListenAsync())
-        {
-            if (++i >= 10)
-                break;
-        }
-
-        // Assert
-        i.Should().Be(10);
-    }
-
-    [Fact(Timeout = 15000)]
     public async Task I_can_execute_a_command_as_a_push_based_event_stream()
     {
         // Arrange

--- a/CliWrap.Tests/EventStreamSpecs.cs
+++ b/CliWrap.Tests/EventStreamSpecs.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Linq;
@@ -29,6 +31,51 @@ public class EventStreamSpecs
         events.OfType<StandardErrorCommandEvent>().Should().HaveCount(100);
         events.OfType<ExitedCommandEvent>().Should().ContainSingle();
         events.OfType<ExitedCommandEvent>().Single().ExitCode.Should().Be(0);
+    }
+
+    [Fact(Timeout = 15000)]
+    public async Task I_can_stop_listening_to_a_pull_based_event_stream_early()
+    {
+        // https://github.com/Tyrrrz/CliWrap/issues/336
+
+        // Arrange
+        var unobservedExceptions = new ConcurrentBag<Exception>();
+
+        void OnUnobservedException(object? sender, UnobservedTaskExceptionEventArgs e)
+        {
+            unobservedExceptions.Add(e.Exception);
+            e.SetObserved();
+        }
+
+        TaskScheduler.UnobservedTaskException += OnUnobservedException;
+
+        // Keep the process alive after the iterator is disposed, so its completion continuation
+        // attempts to close the channel after enumeration has stopped.
+        var cmd = Cli.Wrap(Dummy.Program.FilePath).WithArguments(["sleep", "00:00:00.1"]);
+
+        // Act
+        try
+        {
+            for (var i = 0; i < 10; i++)
+            {
+                await foreach (var _ in cmd.ListenAsync())
+                {
+                    break;
+                }
+            }
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+            await Task.Delay(500);
+        }
+        finally
+        {
+            TaskScheduler.UnobservedTaskException -= OnUnobservedException;
+        }
+
+        // Assert
+        unobservedExceptions.Should().BeEmpty();
     }
 
     [Fact(Timeout = 15000)]

--- a/CliWrap.Tests/PipingSpecs.cs
+++ b/CliWrap.Tests/PipingSpecs.cs
@@ -276,7 +276,7 @@ public class PipingSpecs
         var stdOutLinesCount = 0;
 
         var cmd =
-            Cli.Wrap(Dummy.Program.FilePath).WithArguments(["generate text", "--lines", "100"])
+            Cli.Wrap(Dummy.Program.FilePath).WithArguments(["generate text", "--lines", "1000"])
             | (
                 async line =>
                 {
@@ -289,7 +289,7 @@ public class PipingSpecs
         await cmd.ExecuteAsync();
 
         // Assert
-        stdOutLinesCount.Should().Be(100);
+        stdOutLinesCount.Should().Be(1000);
     }
 
     [Fact(Timeout = 15000)]
@@ -299,7 +299,7 @@ public class PipingSpecs
         var stdOutLinesCount = 0;
 
         var cmd =
-            Cli.Wrap(Dummy.Program.FilePath).WithArguments(["generate text", "--lines", "100"])
+            Cli.Wrap(Dummy.Program.FilePath).WithArguments(["generate text", "--lines", "1000"])
             | (
                 async (_, cancellationToken) =>
                 {
@@ -312,7 +312,7 @@ public class PipingSpecs
         await cmd.ExecuteAsync();
 
         // Assert
-        stdOutLinesCount.Should().Be(100);
+        stdOutLinesCount.Should().Be(1000);
     }
 
     [Fact(Timeout = 15000)]
@@ -322,14 +322,14 @@ public class PipingSpecs
         var stdOutLinesCount = 0;
 
         var cmd =
-            Cli.Wrap(Dummy.Program.FilePath).WithArguments(["generate text", "--lines", "100"])
+            Cli.Wrap(Dummy.Program.FilePath).WithArguments(["generate text", "--lines", "1000"])
             | (_ => stdOutLinesCount++);
 
         // Act
         await cmd.ExecuteAsync();
 
         // Assert
-        stdOutLinesCount.Should().Be(100);
+        stdOutLinesCount.Should().Be(1000);
     }
 
     [Fact(Timeout = 15000)]
@@ -393,15 +393,15 @@ public class PipingSpecs
 
         var cmd =
             Cli.Wrap(Dummy.Program.FilePath)
-                .WithArguments(["generate text", "--target", "all", "--lines", "100"])
+                .WithArguments(["generate text", "--target", "all", "--lines", "1000"])
             | (HandleStdOutAsync, HandleStdErrAsync);
 
         // Act
         await cmd.ExecuteAsync();
 
         // Assert
-        stdOutLinesCount.Should().Be(100);
-        stdErrLinesCount.Should().Be(100);
+        stdOutLinesCount.Should().Be(1000);
+        stdErrLinesCount.Should().Be(1000);
     }
 
     [Fact(Timeout = 15000)]
@@ -425,15 +425,15 @@ public class PipingSpecs
 
         var cmd =
             Cli.Wrap(Dummy.Program.FilePath)
-                .WithArguments(["generate text", "--target", "all", "--lines", "100"])
+                .WithArguments(["generate text", "--target", "all", "--lines", "1000"])
             | (HandleStdOutAsync, HandleStdErrAsync);
 
         // Act
         await cmd.ExecuteAsync();
 
         // Assert
-        stdOutLinesCount.Should().Be(100);
-        stdErrLinesCount.Should().Be(100);
+        stdOutLinesCount.Should().Be(1000);
+        stdErrLinesCount.Should().Be(1000);
     }
 
     [Fact(Timeout = 15000)]
@@ -445,15 +445,15 @@ public class PipingSpecs
 
         var cmd =
             Cli.Wrap(Dummy.Program.FilePath)
-                .WithArguments(["generate text", "--target", "all", "--lines", "100"])
+                .WithArguments(["generate text", "--target", "all", "--lines", "1000"])
             | (_ => stdOutLinesCount++, _ => stdErrLinesCount++);
 
         // Act
         await cmd.ExecuteAsync();
 
         // Assert
-        stdOutLinesCount.Should().Be(100);
-        stdErrLinesCount.Should().Be(100);
+        stdOutLinesCount.Should().Be(1000);
+        stdErrLinesCount.Should().Be(1000);
     }
 
     [Fact(Timeout = 15000)]
@@ -608,7 +608,7 @@ public class PipingSpecs
         var delegateLines = new List<string>();
 
         var cmd =
-            Cli.Wrap(Dummy.Program.FilePath).WithArguments(["generate text", "--lines", "100"])
+            Cli.Wrap(Dummy.Program.FilePath).WithArguments(["generate text", "--lines", "1000"])
             | delegateLines.Add;
 
         // Act

--- a/CliWrap.Tests/TestCollections.cs
+++ b/CliWrap.Tests/TestCollections.cs
@@ -1,7 +1,0 @@
-using Xunit;
-
-namespace CliWrap.Tests;
-
-// Don't run these tests in parallel because they rely on observing global state
-[CollectionDefinition(nameof(NonParallelCollection), DisableParallelization = true)]
-public class NonParallelCollection;

--- a/CliWrap.Tests/TestCollections.cs
+++ b/CliWrap.Tests/TestCollections.cs
@@ -1,0 +1,7 @@
+using Xunit;
+
+namespace CliWrap.Tests;
+
+// Don't run these tests in parallel because they rely on observing global state
+[CollectionDefinition(nameof(NonParallelCollection), DisableParallelization = true)]
+public class NonParallelCollection;

--- a/CliWrap/Buffered/BufferedCommandExtensions.cs
+++ b/CliWrap/Buffered/BufferedCommandExtensions.cs
@@ -50,7 +50,7 @@ public static class BufferedCommandExtensions
                 {
                     try
                     {
-                        var result = await task;
+                        var result = await task.ConfigureAwait(false);
 
                         return new BufferedCommandResult(
                             result.ExitCode,

--- a/CliWrap/Buffered/BufferedCommandExtensions.cs
+++ b/CliWrap/Buffered/BufferedCommandExtensions.cs
@@ -41,11 +41,10 @@ public static class BufferedCommandExtensions
                 PipeTarget.ToStringBuilder(stdErrBuffer, standardErrorEncoding)
             );
 
-            var commandWithPipes = command
+            // Execute the command with the pipes extended to capture the output and error streams into buffers
+            return command
                 .WithStandardOutputPipe(stdOutPipe)
-                .WithStandardErrorPipe(stdErrPipe);
-
-            return commandWithPipes
+                .WithStandardErrorPipe(stdErrPipe)
                 .ExecuteAsync(forcefulCancellationToken, gracefulCancellationToken)
                 .Bind(async task =>
                 {
@@ -90,15 +89,13 @@ public static class BufferedCommandExtensions
             Encoding standardOutputEncoding,
             Encoding standardErrorEncoding,
             CancellationToken cancellationToken = default
-        )
-        {
-            return command.ExecuteBufferedAsync(
+        ) =>
+            command.ExecuteBufferedAsync(
                 standardOutputEncoding,
                 standardErrorEncoding,
                 cancellationToken,
                 CancellationToken.None
             );
-        }
 
         /// <summary>
         /// Executes the command asynchronously with buffering.
@@ -111,10 +108,7 @@ public static class BufferedCommandExtensions
         public CommandTask<BufferedCommandResult> ExecuteBufferedAsync(
             Encoding encoding,
             CancellationToken cancellationToken = default
-        )
-        {
-            return command.ExecuteBufferedAsync(encoding, encoding, cancellationToken);
-        }
+        ) => command.ExecuteBufferedAsync(encoding, encoding, cancellationToken);
 
         /// <summary>
         /// Executes the command asynchronously with buffering.
@@ -127,9 +121,6 @@ public static class BufferedCommandExtensions
         /// </remarks>
         public CommandTask<BufferedCommandResult> ExecuteBufferedAsync(
             CancellationToken cancellationToken = default
-        )
-        {
-            return command.ExecuteBufferedAsync(Encoding.Default, cancellationToken);
-        }
+        ) => command.ExecuteBufferedAsync(Encoding.Default, cancellationToken);
     }
 }

--- a/CliWrap/Command.Execution.cs
+++ b/CliWrap/Command.Execution.cs
@@ -159,13 +159,16 @@ public partial class Command
                     .WaitAsync(cancellationToken)
                     .ConfigureAwait(false);
             }
-            // Expect IOException: "The pipe has been ended" (Windows) or "Broken pipe" (Unix).
-            // This may happen if the process terminated before the pipe has been exhausted.
-            // It's not an exceptional situation because the process may not need the entire
-            // stdin to complete successfully.
-            // Don't catch derived exceptions, such as FileNotFoundException, to avoid false positives.
-            // We also can't rely on process.HasExited here because of potential race conditions.
-            catch (IOException ex) when (ex.GetType() == typeof(IOException)) { }
+            catch (IOException ex)
+                // Don't catch derived exceptions, such as FileNotFoundException, to avoid false positives.
+                // We also can't rely on process.HasExited here because of potential race conditions.
+                when (ex.GetType() == typeof(IOException))
+            {
+                // Expect IOException: "The pipe has been ended" (Windows) or "Broken pipe" (Unix).
+                // This may happen if the process terminated before the pipe has been exhausted.
+                // It's not an exceptional situation because the process may not need the entire
+                // stdin to complete successfully.
+            }
         }
     }
 
@@ -250,39 +253,37 @@ public partial class Command
         catch (OperationCanceledException ex) when (ex.CancellationToken == waitTimeoutCts.Token)
         {
             // We tried to kill the process, but it didn't exit within the allotted timeout, meaning
-            // that the termination attempt failed. This should never happen, but inform the user if it does.
+            // that the termination attempt failed. This should never happen, but it's not impossible.
             throw new TimeoutException(
                 $"Failed to terminate the underlying process ({process.Name}#{process.Id}) within the allotted timeout.",
                 ex
             );
         }
-        catch (OperationCanceledException ex) when (ex.CancellationToken == stdInCts.Token)
-        {
-            // This clause will be hit both when stdin piping is canceled due to process exit
-            // and when it aborts due to an actual cancellation request (because of the link).
-            // Swallow this exception because it was triggered by an internal cancellation,
-            // we will throw a more meaningful one later if needed.
-        }
         catch (OperationCanceledException ex)
-            when (ex.CancellationToken == forcefulCancellationToken
-                || ex.CancellationToken == gracefulCancellationToken
+            when (ex.CancellationToken == stdInCts.Token
+                && !forcefulCancellationToken.IsCancellationRequested
             )
         {
-            // This clause should never hit due to the registrations above, but just in case it does,
-            // swallow the exception here to throw a more meaningful one later.
+            // The process has exited on its own, but the stdin pipe was still trying to write data to it.
+            // This is an internal cancellation that is not meant to be surfaced to the user.
         }
-
-        // Check if the process exited after forceful cancellation
-        if (forcefulCancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException ex)
+            // The exception's own token may be the stdin cancellation token, because it's linked,
+            // so we need to check the forceful cancellation token directly.
+            when (forcefulCancellationToken.IsCancellationRequested)
         {
+            // We tried to kill the process and it exited. Rethrow a more meaningful exception.
             throw new OperationCanceledException(
                 "Command execution canceled. "
                     + $"Underlying process ({process.Name}#{process.Id}) was forcefully terminated.",
+                ex,
                 forcefulCancellationToken
             );
         }
 
-        // Check if the process exited after graceful cancellation
+        // The process has exited on its own, but it might have done so because we requested a graceful cancellation.
+        // Check the token manually because we don't pass it to any of the other methods and won't get the exception
+        // propagated automatically.
         if (gracefulCancellationToken.IsCancellationRequested)
         {
             throw new OperationCanceledException(

--- a/CliWrap/Command.Execution.cs
+++ b/CliWrap/Command.Execution.cs
@@ -270,12 +270,18 @@ public partial class Command
                 ex
             );
         }
-        catch (OperationCanceledException) when (forcefulCancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException)
+            // Not checking ex.CancellationToken here because it will always be stdInCts.Token
+            // at this point due to the link.
+            when (forcefulCancellationToken.IsCancellationRequested)
         {
             // The operation was cancelled forcefully by the user. Suppress this exception as we'll throw
             // a more meaningful one later.
         }
-        catch (OperationCanceledException) when (gracefulCancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException)
+            // Not checking ex.CancellationToken here because it will always be stdInCts.Token
+            // at this point due to the link.
+            when (gracefulCancellationToken.IsCancellationRequested)
         {
             // The operation was cancelled gracefully by the user. Suppress this exception as we'll throw
             // a more meaningful one later.

--- a/CliWrap/Command.Execution.cs
+++ b/CliWrap/Command.Execution.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using CliWrap.Exceptions;
 using CliWrap.Utils;
+using CliWrap.Utils.Extensions;
 using PowerKit.Extensions;
 
 namespace CliWrap;
@@ -144,10 +145,11 @@ public partial class Command
     {
         await using (process.StandardInput.ToAsyncDisposable())
         {
+            var copyTask = StandardInputPipe.CopyToAsync(process.StandardInput, cancellationToken);
+
             try
             {
-                await StandardInputPipe
-                    .CopyToAsync(process.StandardInput, cancellationToken)
+                await copyTask
                     // The input pipe may never respond to cancellation, so we add a fallback
                     // that drops the task and returns early when cancellation is requested.
                     // This prevents hanging when the process exits before consuming all stdin data.
@@ -158,6 +160,14 @@ public partial class Command
                     // respects cancellation. Otherwise, we may as well add such fallbacks everywhere.
                     .WaitAsync(cancellationToken)
                     .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // CopyToAsync() may not honor cancellation and can fault after WaitAsync() returns.
+                // Observe that fault to avoid unobserved task exceptions.
+                _ = copyTask.ObserveException();
+
+                throw;
             }
             catch (IOException ex)
                 // Don't catch derived exceptions, such as FileNotFoundException, to avoid false positives.

--- a/CliWrap/Command.Execution.cs
+++ b/CliWrap/Command.Execution.cs
@@ -270,16 +270,22 @@ public partial class Command
                 ex
             );
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (forcefulCancellationToken.IsCancellationRequested)
         {
-            // The rest of cancellation exceptions bubble up here as a result of either user-requested
-            // cancellation, or due to other internal cancellations.
-            // We only care about the former, but it's way easier and more reliable to handle them separately
-            // so we do that below.
+            // The operation was cancelled forcefully by the user. Suppress this exception as we'll throw
+            // a more meaningful one later.
+        }
+        catch (OperationCanceledException) when (gracefulCancellationToken.IsCancellationRequested)
+        {
+            // The operation was cancelled gracefully by the user. Suppress this exception as we'll throw
+            // a more meaningful one later.
+        }
+        catch (OperationCanceledException ex) when (ex.CancellationToken == stdInCts.Token)
+        {
+            // The process exited before consuming all stdin, ignore this internal cancellation
         }
 
-        // The process may exit after the cancellation request but before an awaited operation
-        // observes it. In that case, cancellation still takes precedence over exit-code validation.
+        // Handle forceful cancellation
         if (forcefulCancellationToken.IsCancellationRequested)
         {
             throw new OperationCanceledException(
@@ -289,9 +295,7 @@ public partial class Command
             );
         }
 
-        // The process has exited on its own, but it might have done so because we requested a graceful cancellation.
-        // Check the token manually because we don't pass it to any of the other methods and won't get the exception
-        // propagated automatically.
+        // Handle graceful cancellation
         if (gracefulCancellationToken.IsCancellationRequested)
         {
             throw new OperationCanceledException(

--- a/CliWrap/Command.Execution.cs
+++ b/CliWrap/Command.Execution.cs
@@ -270,24 +270,21 @@ public partial class Command
                 ex
             );
         }
-        catch (OperationCanceledException ex)
-            when (ex.CancellationToken == stdInCts.Token
-                && !forcefulCancellationToken.IsCancellationRequested
-            )
+        catch (OperationCanceledException)
         {
-            // The process has exited on its own, but the stdin pipe was still trying to write data to it.
-            // This is an internal cancellation that is not meant to be surfaced to the user.
+            // The rest of cancellation exceptions bubble up here as a result of either user-requested
+            // cancellation, or due to other internal cancellations.
+            // We only care about the former, but it's way easier and more reliable to handle them separately
+            // so we do that below.
         }
-        catch (OperationCanceledException ex)
-            // The exception's own token may be the stdin cancellation token, because it's linked,
-            // so we need to check the forceful cancellation token directly.
-            when (forcefulCancellationToken.IsCancellationRequested)
+
+        // The process may exit after the cancellation request but before an awaited operation
+        // observes it. In that case, cancellation still takes precedence over exit-code validation.
+        if (forcefulCancellationToken.IsCancellationRequested)
         {
-            // We tried to kill the process and it exited. Rethrow a more meaningful exception.
             throw new OperationCanceledException(
                 "Command execution canceled. "
                     + $"Underlying process ({process.Name}#{process.Id}) was forcefully terminated.",
-                ex,
                 forcefulCancellationToken
             );
         }

--- a/CliWrap/Command.Execution.cs
+++ b/CliWrap/Command.Execution.cs
@@ -163,8 +163,9 @@ public partial class Command
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
-                // CopyToAsync() may not honor cancellation and can fault after WaitAsync() returns.
-                // Observe that fault to avoid unobserved task exceptions.
+                // We tried to cancel the copy task and abandoned it. If it did not respond to
+                // cancellation, it will remain in a detached state, so we need to observe its
+                // exception so it doesn't get reported to the finalizer thread and crash the process.
                 _ = copyTask.ObserveException();
 
                 throw;

--- a/CliWrap/CommandResult.cs
+++ b/CliWrap/CommandResult.cs
@@ -13,7 +13,7 @@ public partial class CommandResult(int exitCode, DateTimeOffset startTime, DateT
     public int ExitCode { get; } = exitCode;
 
     /// <summary>
-    /// Whether the command execution was successful (i.e. exit code is zero).
+    /// Whether the command execution was successful (i.e., exit code is zero).
     /// </summary>
     public bool IsSuccess => ExitCode == 0;
 

--- a/CliWrap/EventStream/PullEventStreamCommandExtensions.cs
+++ b/CliWrap/EventStream/PullEventStreamCommandExtensions.cs
@@ -110,7 +110,7 @@ public static partial class EventStreamCommandExtensions
                 )
             );
 
-            // Execute the command with the pipes extended to report events to the channel
+            // Execute the command with the pipes extended to transmit events to the channel
             var commandTask = command
                 .WithStandardOutputPipe(stdOutPipe)
                 .WithStandardErrorPipe(stdErrPipe)

--- a/CliWrap/EventStream/PullEventStreamCommandExtensions.cs
+++ b/CliWrap/EventStream/PullEventStreamCommandExtensions.cs
@@ -39,7 +39,7 @@ public static partial class EventStreamCommandExtensions
                     async (line, innerCancellationToken) =>
                     {
                         await channel
-                            .PublishAsync(
+                            .TransmitAsync(
                                 new StandardOutputCommandEvent(line),
                                 innerCancellationToken
                             )
@@ -55,7 +55,7 @@ public static partial class EventStreamCommandExtensions
                     async (line, innerCancellationToken) =>
                     {
                         await channel
-                            .PublishAsync(
+                            .TransmitAsync(
                                 new StandardErrorCommandEvent(line),
                                 innerCancellationToken
                             )
@@ -65,23 +65,19 @@ public static partial class EventStreamCommandExtensions
                 )
             );
 
-            var commandWithPipes = command
+            // Execute the command with the pipes extended to report events to the channel
+            var commandTask = command
                 .WithStandardOutputPipe(stdOutPipe)
-                .WithStandardErrorPipe(stdErrPipe);
-
-            var commandTask = commandWithPipes.ExecuteAsync(
-                forcefulCancellationToken,
-                gracefulCancellationToken
-            );
+                .WithStandardErrorPipe(stdErrPipe)
+                .ExecuteAsync(forcefulCancellationToken, gracefulCancellationToken);
 
             yield return new StartedCommandEvent(commandTask.ProcessId);
 
-            var completionTask = commandTask
+            // Close the channel when the command finishes executing, so that the consumer can stop listening
+            var channelTask = commandTask
                 .Task.ContinueWith(
                     async _ =>
-                        await channel
-                            .ReportCompletionAsync(forcefulCancellationToken)
-                            .ConfigureAwait(false),
+                        await channel.CloseAsync(forcefulCancellationToken).ConfigureAwait(false),
                     // Run the continuation even if the parent task failed
                     TaskContinuationOptions.None
                 )
@@ -102,12 +98,12 @@ public static partial class EventStreamCommandExtensions
             {
                 try
                 {
-                    await completionTask.ConfigureAwait(false);
+                    await channelTask.ConfigureAwait(false);
                 }
-                catch (Exception ex)
-                    when (ex is OperationCanceledException or ObjectDisposedException)
+                catch (OperationCanceledException)
                 {
-                    // Channel has already closed
+                    // Ignore the internal cancellation exception here as we will throw
+                    // a more meaningful one by awaiting the command task below.
                 }
             }
 
@@ -125,15 +121,13 @@ public static partial class EventStreamCommandExtensions
             Encoding standardOutputEncoding,
             Encoding standardErrorEncoding,
             CancellationToken cancellationToken = default
-        )
-        {
-            return command.ListenAsync(
+        ) =>
+            command.ListenAsync(
                 standardOutputEncoding,
                 standardErrorEncoding,
                 cancellationToken,
                 CancellationToken.None
             );
-        }
 
         /// <summary>
         /// Executes the command as a pull-based event stream.
@@ -144,10 +138,7 @@ public static partial class EventStreamCommandExtensions
         public IAsyncEnumerable<CommandEvent> ListenAsync(
             Encoding encoding,
             CancellationToken cancellationToken = default
-        )
-        {
-            return command.ListenAsync(encoding, encoding, cancellationToken);
-        }
+        ) => command.ListenAsync(encoding, encoding, cancellationToken);
 
         /// <summary>
         /// Executes the command as a pull-based event stream.
@@ -158,9 +149,6 @@ public static partial class EventStreamCommandExtensions
         /// </remarks>
         public IAsyncEnumerable<CommandEvent> ListenAsync(
             CancellationToken cancellationToken = default
-        )
-        {
-            return command.ListenAsync(Encoding.Default, cancellationToken);
-        }
+        ) => command.ListenAsync(Encoding.Default, cancellationToken);
     }
 }

--- a/CliWrap/EventStream/PullEventStreamCommandExtensions.cs
+++ b/CliWrap/EventStream/PullEventStreamCommandExtensions.cs
@@ -98,6 +98,9 @@ public static partial class EventStreamCommandExtensions
             {
                 try
                 {
+                    // Await the channel task to ensure that the channel is closed and all events are flushed
+                    // before the iterator completes and the channel (along with its semaphore) is disposed.
+                    // Otherwise, this task may produce an unobserved exception.
                     await channelTask.ConfigureAwait(false);
                 }
                 catch (OperationCanceledException)

--- a/CliWrap/EventStream/PullEventStreamCommandExtensions.cs
+++ b/CliWrap/EventStream/PullEventStreamCommandExtensions.cs
@@ -70,7 +70,7 @@ public static partial class EventStreamCommandExtensions
                                 && abandonCts.IsCancellationRequested
                             )
                         {
-                            // The iterator was abandoned during publish, ignore
+                            // The iterator was abandoned during transmit, ignore
                         }
                     },
                     standardOutputEncoding
@@ -103,7 +103,7 @@ public static partial class EventStreamCommandExtensions
                                 && abandonCts.IsCancellationRequested
                             )
                         {
-                            // The iterator was abandoned during publish, ignore
+                            // The iterator was abandoned during transmit, ignore
                         }
                     },
                     standardErrorEncoding

--- a/CliWrap/EventStream/PullEventStreamCommandExtensions.cs
+++ b/CliWrap/EventStream/PullEventStreamCommandExtensions.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using CliWrap.Utils;
+using CliWrap.Utils.Extensions;
 
 namespace CliWrap.EventStream;
 
@@ -33,17 +34,44 @@ public static partial class EventStreamCommandExtensions
         {
             using var channel = new Channel<CommandEvent>();
 
+            // The consumer may abandon the iterator, leaving it in a hanging but uncanceled state.
+            // In that case, we want the process to continue running in the background, but we also
+            // need to bypass the channel to drain the pipes without waiting for transmit/receive locks.
+            using var abandonCts = CancellationTokenSource.CreateLinkedTokenSource(
+                forcefulCancellationToken
+            );
+
             var stdOutPipe = PipeTarget.Merge(
                 command.StandardOutputPipe,
                 PipeTarget.ToDelegate(
                     async (line, innerCancellationToken) =>
                     {
-                        await channel
-                            .TransmitAsync(
-                                new StandardOutputCommandEvent(line),
-                                innerCancellationToken
+                        // If the iterator was abandoned, then just turn this pipe into a no-op
+                        // so that it drains the process's output stream without deadlocking on the channel.
+                        if (abandonCts.IsCancellationRequested)
+                            return;
+
+                        try
+                        {
+                            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+                                innerCancellationToken,
+                                abandonCts.Token
+                            );
+
+                            await channel
+                                .TransmitAsync(
+                                    new StandardOutputCommandEvent(line),
+                                    linkedCts.Token
+                                )
+                                .ConfigureAwait(false);
+                        }
+                        catch (Exception ex)
+                            when ((ex is OperationCanceledException or ObjectDisposedException)
+                                && abandonCts.IsCancellationRequested
                             )
-                            .ConfigureAwait(false);
+                        {
+                            // The iterator was abandoned during publish, ignore
+                        }
                     },
                     standardOutputEncoding
                 )
@@ -54,12 +82,29 @@ public static partial class EventStreamCommandExtensions
                 PipeTarget.ToDelegate(
                     async (line, innerCancellationToken) =>
                     {
-                        await channel
-                            .TransmitAsync(
-                                new StandardErrorCommandEvent(line),
-                                innerCancellationToken
+                        // If the iterator was abandoned, then just turn this pipe into a no-op
+                        // so that it drains the process's error stream without deadlocking on the channel.
+                        if (abandonCts.IsCancellationRequested)
+                            return;
+
+                        try
+                        {
+                            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+                                innerCancellationToken,
+                                abandonCts.Token
+                            );
+
+                            await channel
+                                .TransmitAsync(new StandardErrorCommandEvent(line), linkedCts.Token)
+                                .ConfigureAwait(false);
+                        }
+                        catch (Exception ex)
+                            when ((ex is OperationCanceledException or ObjectDisposedException)
+                                && abandonCts.IsCancellationRequested
                             )
-                            .ConfigureAwait(false);
+                        {
+                            // The iterator was abandoned during publish, ignore
+                        }
                     },
                     standardErrorEncoding
                 )
@@ -80,7 +125,17 @@ public static partial class EventStreamCommandExtensions
                     {
                         // Close the channel when the command finishes executing,
                         // so that the consumer can stop listening.
-                        await channel.CloseAsync(forcefulCancellationToken).ConfigureAwait(false);
+                        try
+                        {
+                            await channel.CloseAsync(abandonCts.Token).ConfigureAwait(false);
+                        }
+                        catch (Exception ex)
+                            when ((ex is OperationCanceledException or ObjectDisposedException)
+                                && abandonCts.IsCancellationRequested
+                            )
+                        {
+                            // The iterator was abandoned as the channel was closing, ignore
+                        }
                     }
                 });
 
@@ -104,12 +159,15 @@ public static partial class EventStreamCommandExtensions
             finally
             {
                 // The code after the yield return statements may not execute if the consumer
-                // breaks out of the loop early or cancels it.
-                // Make sure the command task is awaited to completion no matter what,
-                // so that it doesn't produce unobserved task exceptions.
-                // Note: double-awaiting is safe because tasks are idempotent.
-                // https://github.com/Tyrrrz/CliWrap/issues/336
-                await commandTask.ConfigureAwait(false);
+                // breaks out of the iterator early. Because of that, the pipes will stop
+                // draining properly and the execution may deadlock. To avoid that, we trigger
+                // a token to stop transmitting events so that the command can keep draining its
+                // output without waiting for the consumer to read from the channel.
+                await abandonCts.CancelAsync();
+
+                // The task will remain detached, so observe its exception so it
+                // doesn't get reported to the finalizer thread and crash the process.
+                _ = commandTask.Task.ObserveException();
             }
         }
 

--- a/CliWrap/EventStream/PullEventStreamCommandExtensions.cs
+++ b/CliWrap/EventStream/PullEventStreamCommandExtensions.cs
@@ -69,22 +69,25 @@ public static partial class EventStreamCommandExtensions
             var commandTask = command
                 .WithStandardOutputPipe(stdOutPipe)
                 .WithStandardErrorPipe(stdErrPipe)
-                .ExecuteAsync(forcefulCancellationToken, gracefulCancellationToken);
-
-            yield return new StartedCommandEvent(commandTask.ProcessId);
-
-            // Close the channel when the command finishes executing, so that the consumer can stop listening
-            var channelTask = commandTask
-                .Task.ContinueWith(
-                    async _ =>
-                        await channel.CloseAsync(forcefulCancellationToken).ConfigureAwait(false),
-                    // Run the continuation even if the parent task failed
-                    TaskContinuationOptions.None
-                )
-                .Unwrap();
+                .ExecuteAsync(forcefulCancellationToken, gracefulCancellationToken)
+                .Bind(async task =>
+                {
+                    try
+                    {
+                        return await task.ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        // Close the channel when the command finishes executing,
+                        // so that the consumer can stop listening.
+                        await channel.CloseAsync(forcefulCancellationToken).ConfigureAwait(false);
+                    }
+                });
 
             try
             {
+                yield return new StartedCommandEvent(commandTask.ProcessId);
+
                 await foreach (
                     var cmdEvent in channel
                         .ReceiveAsync(forcefulCancellationToken)
@@ -93,25 +96,21 @@ public static partial class EventStreamCommandExtensions
                 {
                     yield return cmdEvent;
                 }
+
+                var result = await commandTask.ConfigureAwait(false);
+
+                yield return new ExitedCommandEvent(result.ExitCode);
             }
             finally
             {
-                try
-                {
-                    // Await the channel task to ensure that the channel is closed and all events are flushed
-                    // before the iterator completes and the channel (along with its semaphore) is disposed.
-                    // Otherwise, this task may produce an unobserved exception.
-                    await channelTask.ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    // Ignore the internal cancellation exception here as we will throw
-                    // a more meaningful one by awaiting the command task below.
-                }
+                // The code after the yield return statements may not execute if the consumer
+                // breaks out of the loop early or cancels it.
+                // Make sure the command task is awaited to completion no matter what,
+                // so that it doesn't produce unobserved task exceptions.
+                // Note: double-awaiting is safe because tasks are idempotent.
+                // https://github.com/Tyrrrz/CliWrap/issues/336
+                await commandTask.ConfigureAwait(false);
             }
-
-            var result = await commandTask.ConfigureAwait(false);
-            yield return new ExitedCommandEvent(result.ExitCode);
         }
 
         /// <summary>

--- a/CliWrap/EventStream/PushEventStreamCommandExtensions.cs
+++ b/CliWrap/EventStream/PushEventStreamCommandExtensions.cs
@@ -2,8 +2,8 @@ using System;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using CliWrap.Utils.Extensions;
 using PowerKit;
-using PowerKit.Extensions;
 
 namespace CliWrap.EventStream;
 
@@ -55,29 +55,28 @@ public static partial class EventStreamCommandExtensions
 
                 observer.OnNext(new StartedCommandEvent(commandTask.ProcessId));
 
-                // Don't pass cancellation token to the continuation because we need it to
-                // trigger regardless of how the task completed.
-                _ = commandTask.Task.ContinueWith(
-                    t =>
+                _ = commandTask
+                    .Bind(async task =>
                     {
-                        // Canceled tasks don't have exceptions
-                        if (t.IsCanceled)
+                        try
                         {
-                            observer.OnError(new TaskCanceledException(t));
-                        }
-                        else if (t.Exception is not null)
-                        {
-                            observer.OnError(t.Exception.TryGetSingle() ?? t.Exception);
-                        }
-                        else
-                        {
-                            observer.OnNext(new ExitedCommandEvent(t.Result.ExitCode));
+                            var result = await task.ConfigureAwait(false);
+
+                            observer.OnNext(new ExitedCommandEvent(result.ExitCode));
                             observer.OnCompleted();
                         }
-                    },
-                    // Run the continuation even if the parent task failed
-                    TaskContinuationOptions.None
-                );
+                        catch (OperationCanceledException) when (task.IsCanceled)
+                        {
+                            observer.OnError(new TaskCanceledException(task));
+                        }
+                        catch (Exception ex)
+                        {
+                            observer.OnError(ex);
+                        }
+
+                        return true;
+                    })
+                    .Task.ObserveException();
 
                 return Disposable.Null;
             });

--- a/CliWrap/EventStream/PushEventStreamCommandExtensions.cs
+++ b/CliWrap/EventStream/PushEventStreamCommandExtensions.cs
@@ -51,17 +51,18 @@ public static partial class EventStreamCommandExtensions
                 var commandTask = command
                     .WithStandardOutputPipe(stdOutPipe)
                     .WithStandardErrorPipe(stdErrPipe)
-                    .ExecuteAsync(forcefulCancellationToken, gracefulCancellationToken)
+                    .ExecuteAsync(forcefulCancellationToken, gracefulCancellationToken);
+
+                observer.OnNext(new StartedCommandEvent(commandTask.ProcessId));
+
+                _ = commandTask
                     .Bind(async task =>
                     {
+                        CommandResult result;
+
                         try
                         {
-                            var result = await task.ConfigureAwait(false);
-
-                            observer.OnNext(new ExitedCommandEvent(result.ExitCode));
-                            observer.OnCompleted();
-
-                            return result;
+                            result = await task.ConfigureAwait(false);
                         }
                         catch (OperationCanceledException) when (task.IsCanceled)
                         {
@@ -73,12 +74,16 @@ public static partial class EventStreamCommandExtensions
                             observer.OnError(ex);
                             throw;
                         }
-                    });
 
-                // Since the command task is detached, we need to observe its exception to avoid unobserved task exceptions
-                _ = commandTask.Task.ObserveException();
+                        // Execute these outside of try/catch to avoid catching exceptions from observer callbacks.
+                        // Otherwise, we may get an error event after the completion event.
+                        observer.OnNext(new ExitedCommandEvent(result.ExitCode));
+                        observer.OnCompleted();
 
-                observer.OnNext(new StartedCommandEvent(commandTask.ProcessId));
+                        return result;
+                    })
+                    // Since the command task is detached, we need to observe it to avoid unobserved task exceptions
+                    .Task.ObserveException();
 
                 return Disposable.Null;
             });

--- a/CliWrap/EventStream/PushEventStreamCommandExtensions.cs
+++ b/CliWrap/EventStream/PushEventStreamCommandExtensions.cs
@@ -28,9 +28,8 @@ public static partial class EventStreamCommandExtensions
             Encoding standardErrorEncoding,
             CancellationToken forcefulCancellationToken,
             CancellationToken gracefulCancellationToken
-        )
-        {
-            return Observable.CreateSynchronized<CommandEvent>(observer =>
+        ) =>
+            Observable.CreateSynchronized<CommandEvent>(observer =>
             {
                 var stdOutPipe = PipeTarget.Merge(
                     command.StandardOutputPipe,
@@ -48,14 +47,11 @@ public static partial class EventStreamCommandExtensions
                     )
                 );
 
-                var commandWithPipes = command
+                // Execute the command with the pipes extended to push events to the observer
+                var commandTask = command
                     .WithStandardOutputPipe(stdOutPipe)
-                    .WithStandardErrorPipe(stdErrPipe);
-
-                var commandTask = commandWithPipes.ExecuteAsync(
-                    forcefulCancellationToken,
-                    gracefulCancellationToken
-                );
+                    .WithStandardErrorPipe(stdErrPipe)
+                    .ExecuteAsync(forcefulCancellationToken, gracefulCancellationToken);
 
                 observer.OnNext(new StartedCommandEvent(commandTask.ProcessId));
 
@@ -79,12 +75,12 @@ public static partial class EventStreamCommandExtensions
                             observer.OnCompleted();
                         }
                     },
+                    // Run the continuation even if the parent task failed
                     TaskContinuationOptions.None
                 );
 
                 return Disposable.Null;
             });
-        }
 
         /// <summary>
         /// Executes the command as a push-based event stream.
@@ -96,15 +92,13 @@ public static partial class EventStreamCommandExtensions
             Encoding standardOutputEncoding,
             Encoding standardErrorEncoding,
             CancellationToken cancellationToken = default
-        )
-        {
-            return command.Observe(
+        ) =>
+            command.Observe(
                 standardOutputEncoding,
                 standardErrorEncoding,
                 cancellationToken,
                 CancellationToken.None
             );
-        }
 
         /// <summary>
         /// Executes the command as a push-based event stream.
@@ -115,10 +109,7 @@ public static partial class EventStreamCommandExtensions
         public IObservable<CommandEvent> Observe(
             Encoding encoding,
             CancellationToken cancellationToken = default
-        )
-        {
-            return command.Observe(encoding, encoding, cancellationToken);
-        }
+        ) => command.Observe(encoding, encoding, cancellationToken);
 
         /// <summary>
         /// Executes the command as a push-based event stream.
@@ -127,9 +118,7 @@ public static partial class EventStreamCommandExtensions
         /// <remarks>
         /// Use pattern matching to handle specific instances of <see cref="CommandEvent" />.
         /// </remarks>
-        public IObservable<CommandEvent> Observe(CancellationToken cancellationToken = default)
-        {
-            return command.Observe(Encoding.Default, cancellationToken);
-        }
+        public IObservable<CommandEvent> Observe(CancellationToken cancellationToken = default) =>
+            command.Observe(Encoding.Default, cancellationToken);
     }
 }

--- a/CliWrap/EventStream/PushEventStreamCommandExtensions.cs
+++ b/CliWrap/EventStream/PushEventStreamCommandExtensions.cs
@@ -51,11 +51,7 @@ public static partial class EventStreamCommandExtensions
                 var commandTask = command
                     .WithStandardOutputPipe(stdOutPipe)
                     .WithStandardErrorPipe(stdErrPipe)
-                    .ExecuteAsync(forcefulCancellationToken, gracefulCancellationToken);
-
-                observer.OnNext(new StartedCommandEvent(commandTask.ProcessId));
-
-                _ = commandTask
+                    .ExecuteAsync(forcefulCancellationToken, gracefulCancellationToken)
                     .Bind(async task =>
                     {
                         try
@@ -64,19 +60,25 @@ public static partial class EventStreamCommandExtensions
 
                             observer.OnNext(new ExitedCommandEvent(result.ExitCode));
                             observer.OnCompleted();
+
+                            return result;
                         }
                         catch (OperationCanceledException) when (task.IsCanceled)
                         {
                             observer.OnError(new TaskCanceledException(task));
+                            throw;
                         }
                         catch (Exception ex)
                         {
                             observer.OnError(ex);
+                            throw;
                         }
+                    });
 
-                        return true;
-                    })
-                    .Task.ObserveException();
+                observer.OnNext(new StartedCommandEvent(commandTask.ProcessId));
+
+                // Since the command task is detached, we need to observe its exception to avoid unobserved task exceptions
+                _ = commandTask.Task.ObserveException();
 
                 return Disposable.Null;
             });

--- a/CliWrap/EventStream/PushEventStreamCommandExtensions.cs
+++ b/CliWrap/EventStream/PushEventStreamCommandExtensions.cs
@@ -82,7 +82,8 @@ public static partial class EventStreamCommandExtensions
 
                         return result;
                     })
-                    // Since the command task is detached, we need to observe it to avoid unobserved task exceptions
+                    // The task will remain detached, so observe its exception so it
+                    // doesn't get reported to the finalizer thread and crash the process.
                     .Task.ObserveException();
 
                 return Disposable.Null;

--- a/CliWrap/EventStream/PushEventStreamCommandExtensions.cs
+++ b/CliWrap/EventStream/PushEventStreamCommandExtensions.cs
@@ -75,10 +75,10 @@ public static partial class EventStreamCommandExtensions
                         }
                     });
 
-                observer.OnNext(new StartedCommandEvent(commandTask.ProcessId));
-
                 // Since the command task is detached, we need to observe its exception to avoid unobserved task exceptions
                 _ = commandTask.Task.ObserveException();
+
+                observer.OnNext(new StartedCommandEvent(commandTask.ProcessId));
 
                 return Disposable.Null;
             });

--- a/CliWrap/Utils/Channel.cs
+++ b/CliWrap/Utils/Channel.cs
@@ -9,18 +9,18 @@ namespace CliWrap.Utils;
 
 internal class Channel<T> : IDisposable
 {
-    private readonly SemaphoreSlim _writeLock = new(1, 1);
-    private readonly SemaphoreSlim _readLock = new(0, 1);
+    private readonly SemaphoreSlim _transmitLock = new(1, 1);
+    private readonly SemaphoreSlim _receiveLock = new(0, 1);
 
     private readonly Cell<T> _cell = new();
 
-    public async Task PublishAsync(T item, CancellationToken cancellationToken = default)
+    public async Task TransmitAsync(T item, CancellationToken cancellationToken = default)
     {
-        await _writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        await _transmitLock.WaitAsync(cancellationToken).ConfigureAwait(false);
 
         _cell.Store(item);
 
-        _readLock.Release();
+        _receiveLock.Release();
     }
 
     public async IAsyncEnumerable<T> ReceiveAsync(
@@ -29,36 +29,36 @@ internal class Channel<T> : IDisposable
     {
         while (true)
         {
-            await _readLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            await _receiveLock.WaitAsync(cancellationToken).ConfigureAwait(false);
 
             if (_cell.TryOpen(out var item))
             {
                 yield return item;
                 _cell.Clear();
             }
-            // If the read lock was released but the cell is empty,
+            // If the receive lock was released but the cell is empty,
             // then the channel has been closed.
             else
             {
                 break;
             }
 
-            _writeLock.Release();
+            _transmitLock.Release();
         }
     }
 
-    public async Task ReportCompletionAsync(CancellationToken cancellationToken = default)
+    public async Task CloseAsync(CancellationToken cancellationToken = default)
     {
-        await _writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        await _transmitLock.WaitAsync(cancellationToken).ConfigureAwait(false);
 
         _cell.Clear();
 
-        _readLock.Release();
+        _receiveLock.Release();
     }
 
     public void Dispose()
     {
-        _writeLock.Dispose();
-        _readLock.Dispose();
+        _transmitLock.Dispose();
+        _receiveLock.Dispose();
     }
 }

--- a/CliWrap/Utils/Extensions/TaskExtensions.cs
+++ b/CliWrap/Utils/Extensions/TaskExtensions.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CliWrap.Utils.Extensions;
+
+internal static class TaskExtensions
+{
+    extension(Task task)
+    {
+        public Task<AggregateException?> ObserveException() =>
+            task.ContinueWith(
+                t => t.Exception,
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted
+                    | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default
+            );
+    }
+}

--- a/CliWrap/Utils/Extensions/TaskExtensions.cs
+++ b/CliWrap/Utils/Extensions/TaskExtensions.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -8,7 +7,7 @@ internal static class TaskExtensions
 {
     extension(Task task)
     {
-        public Task<AggregateException?> ObserveException() =>
+        public Task ObserveException() =>
             task.ContinueWith(
                 t => t.Exception,
                 CancellationToken.None,

--- a/Readme.md
+++ b/Readme.md
@@ -230,7 +230,7 @@ var cmd = Cli.Wrap("git")
 
 Sets the working directory of the child process.
 
-**Default**: current working directory, i.e. `Directory.GetCurrentDirectory()`.
+**Default**: current working directory, i.e., `Directory.GetCurrentDirectory()`.
 
 **Example**:
 


### PR DESCRIPTION
## General description

This PR improves reliability around command cancellation and event streaming.

It ensures that commands behave predictably when event consumers stop listening, avoids unobserved background failures, makes pull- and push-based event streams more consistent, and clarifies the dummy text generator’s output semantics.

## Behaviors that changed

| Scenario | Before | After |
|---|---|---|
| A consumer stops a pull event stream early | The command could block if it continued writing stdout or stderr. | Event delivery stops, while the command continues and its output is drained. |
| A command fails after a pull stream is disposed | Background failures could surface as unobserved task exceptions. | Detached failures are observed internally. |
| A stdin source faults after command cancellation | The late failure could become unobserved. | The late failure is observed internally. |
| A push-stream command completes immediately | Completion could be reported before the start event. | The start event is always reported before completion or failure. |